### PR TITLE
Add info message for successful email address change request

### DIFF
--- a/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
+++ b/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
@@ -38,5 +38,10 @@ class RequestEmailAddressChangePresenter:
                 )
             )
         else:
+            self.notifier.display_info(
+                self.translator.gettext(
+                    "A confirmation mail has been sent to your new email address."
+                )
+            )
             redirect_url = self.url_index.get_user_account_details_url()
         return ViewModel(redirect_url=redirect_url)

--- a/tests/www/presenters/test_request_email_address_change_presenter.py
+++ b/tests/www/presenters/test_request_email_address_change_presenter.py
@@ -79,6 +79,15 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
         )
         assert expected_message not in self.notifier.warnings
 
+    def test_on_success_show_a_info_that_a_confirmation_mail_was_sent(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=False)
+        self.presenter.render_response(response, self._create_form())
+        expected_message = self.translator.gettext(
+            "A confirmation mail has been sent to your new email address."
+        )
+        assert expected_message in self.notifier.infos
+
     def test_that_error_message_is_added_to_new_email_field_on_rejection(self) -> None:
         self.session.login_member(self.member_generator.create_member())
         response = use_case.Response(is_rejected=True)


### PR DESCRIPTION
Before this change it was not clear for users that their request for an email address change has been accepted and that a confirmation mail has been sent out.