### PR TITLE
Undo adding info on p account

### DIFF
--- a/arbeitszeit_flask/templates/user/company_account_p.html
+++ b/arbeitszeit_flask/templates/user/company_account_p.html
@@ -20,13 +20,6 @@
                 <div class="icon"><i class="fas fa-info-circle"></i></div>
                 <p>{{ gettext("The account for fixed means of production.") }}</p>
             </div>
-            <p>
-                {{ gettext("Sum of planned fixed means of production:") }}
-                <span class="has-text-weight-bold">{{ view_model.sum_of_planned_p }}</span>
-            </p>
-            <p>{{ gettext("Sum of consumed fixed means of production:") }}
-                <span  class="has-text-weight-bold">{{ view_model.sum_of_consumed_p }}</span>
-            </p>
             <p>{{ gettext("Balance:") }}
                 <span
                     class="has-text-weight-bold">

--- a/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
@@ -23,8 +23,6 @@ class ShowPAccountDetailsPresenter:
     @dataclass
     class ViewModel:
         transactions: List[ShowPAccountDetailsPresenter.TransactionInfo]
-        sum_of_planned_p: str
-        sum_of_consumed_p: str
         account_balance: str
         plot_url: str
         navbar_items: list[NavbarItem]
@@ -42,8 +40,6 @@ class ShowPAccountDetailsPresenter:
         ]
         return self.ViewModel(
             transactions=transactions,
-            sum_of_planned_p=str(round(use_case_response.sum_of_planned_p, 2)),
-            sum_of_consumed_p=str(round(use_case_response.sum_of_consumed_p, 2)),
             account_balance=str(round(use_case_response.account_balance, 2)),
             plot_url=self.url_index.get_line_plot_of_company_p_account(
                 use_case_response.company_id

--- a/tests/use_cases/test_show_p_account_details.py
+++ b/tests/use_cases/test_show_p_account_details.py
@@ -49,16 +49,6 @@ class ShowPAccountDetailsTests(BaseTestCase):
         response = self.use_case.show_details(self.create_use_case_request(company))
         assert response.account_balance == 0
 
-    def test_sum_of_planned_p_is_zero_when_when_company_has_not_planned_p(self) -> None:
-        company = self.company_generator.create_company()
-        response = self.use_case.show_details(self.create_use_case_request(company))
-        assert response.sum_of_planned_p == 0
-
-    def test_sum_of_consumed_p_is_zero_when_company_has_not_consumed_p(self) -> None:
-        company = self.company_generator.create_company()
-        response = self.use_case.show_details(self.create_use_case_request(company))
-        assert response.sum_of_consumed_p == 0
-
     def test_id_of_the_company_that_owns_the_account_is_returned(self) -> None:
         company = self.company_generator.create_company()
         response = self.use_case.show_details(self.create_use_case_request(company))
@@ -227,38 +217,6 @@ class ShowPAccountDetailsTests(BaseTestCase):
 
         response = self.use_case.show_details(self.create_use_case_request(consumer))
         assert response.account_balance == expected_balance
-
-    def test_that_after_filing_two_plans_the_sum_of_planned_p_is_equal_to_the_sum_of_the_costs_for_p(
-        self,
-    ) -> None:
-        planner = self.company_generator.create_company()
-        costs1 = ProductionCosts(Decimal(1), Decimal(2), Decimal(3))
-        costs2 = ProductionCosts(Decimal(4), Decimal(5), Decimal(6))
-        expected_sum = costs1.means_cost + costs2.means_cost
-        self.plan_generator.create_plan(costs=costs1, amount=1, planner=planner)
-        self.plan_generator.create_plan(costs=costs2, amount=1, planner=planner)
-
-        response = self.use_case.show_details(self.create_use_case_request(planner))
-        assert response.sum_of_planned_p == expected_sum
-
-    def test_that_after_consuming_two_means_of_productions_the_sum_of_consumed_p_is_equal_to_the_sum_of_the_costs(
-        self,
-    ) -> None:
-        consumer = self.company_generator.create_company()
-        costs1 = ProductionCosts(Decimal(1), Decimal(2), Decimal(3))
-        costs2 = ProductionCosts(Decimal(4), Decimal(5), Decimal(6))
-        expected_sum = costs1.total_cost() + costs2.total_cost()
-        plan1 = self.plan_generator.create_plan(costs=costs1, amount=1)
-        self.consumption_generator.create_fixed_means_consumption(
-            consumer=consumer, plan=plan1, amount=1
-        )
-        plan2 = self.plan_generator.create_plan(costs=costs2, amount=1)
-        self.consumption_generator.create_fixed_means_consumption(
-            consumer=consumer, plan=plan2, amount=1
-        )
-
-        response = self.use_case.show_details(self.create_use_case_request(consumer))
-        assert response.sum_of_consumed_p == expected_sum
 
     def test_that_plotting_info_is_empty_when_no_transactions_occurred(self) -> None:
         self.member_generator.create_member()

--- a/tests/www/presenters/test_show_p_account_details.py
+++ b/tests/www/presenters/test_show_p_account_details.py
@@ -58,16 +58,6 @@ class CompanyTransactionsPresenterTests(BaseTestCase):
         )
         self.assertIsInstance(trans.purpose, str)
 
-    def test_that_sum_of_planned_p_is_rounded_to_two_decimal_places(self) -> None:
-        response = self._use_case_response(sum_of_planned_p=Decimal(10.002))
-        view_model = self.presenter.present(response)
-        assert view_model.sum_of_planned_p == "10.00"
-
-    def test_that_sum_of_consumed_p_is_rounded_to_two_decimal_places(self) -> None:
-        response = self._use_case_response(sum_of_consumed_p=Decimal(10.002))
-        view_model = self.presenter.present(response)
-        assert view_model.sum_of_consumed_p == "10.00"
-
     def test_return_two_transactions_when_two_transactions_took_place(self) -> None:
         response = self._use_case_response(
             transactions=[DEFAULT_INFO1, DEFAULT_INFO2], account_balance=Decimal(100)
@@ -106,8 +96,6 @@ class CompanyTransactionsPresenterTests(BaseTestCase):
         self,
         company_id: UUID = uuid4(),
         transactions: List[UseCase.TransactionInfo] | None = None,
-        sum_of_planned_p: Decimal = Decimal(0),
-        sum_of_consumed_p: Decimal = Decimal(0),
         account_balance: Decimal = Decimal(0),
         plot: UseCase.PlotDetails | None = None,
     ) -> UseCase.Response:
@@ -118,8 +106,6 @@ class CompanyTransactionsPresenterTests(BaseTestCase):
         return UseCase.Response(
             company_id=company_id,
             transactions=transactions,
-            sum_of_planned_p=sum_of_planned_p,
-            sum_of_consumed_p=sum_of_consumed_p,
             account_balance=account_balance,
             plot=plot,
         )


### PR DESCRIPTION
In commit efae6e4 we added some additional info to the company p accounts (sum of planned and consumed p). These additions get reverted in the current commit.