### PR TITLE
Create ChangeUserEmailAddressPresenter

### DIFF
--- a/arbeitszeit_web/www/presenters/change_user_email_address_presenter.py
+++ b/arbeitszeit_web/www/presenters/change_user_email_address_presenter.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import change_user_email_address
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirect_url: str | None
+
+
+@dataclass
+class ChangeUserEmailAddressPresenter:
+    notifier: Notifier
+    url_index: UrlIndex
+    translator: Translator
+
+    def render_response(
+        self, response: change_user_email_address.Response
+    ) -> ViewModel:
+        if response.is_rejected:
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "Something went wrong. Perhaps the email address is not valid or already in use."
+                )
+            )
+            return ViewModel(redirect_url=None)
+        else:
+            self.notifier.display_info(
+                self.translator.gettext("Email address changed successfully.")
+            )
+            return ViewModel(redirect_url=self.url_index.get_user_account_details_url())

--- a/tests/www/presenters/test_change_user_email_address_presenter.py
+++ b/tests/www/presenters/test_change_user_email_address_presenter.py
@@ -1,0 +1,52 @@
+from arbeitszeit.use_cases import change_user_email_address
+from arbeitszeit_web.www.presenters.change_user_email_address_presenter import (
+    ChangeUserEmailAddressPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class ChangeUserEmailAddressPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(ChangeUserEmailAddressPresenter)
+
+    def test_that_view_model_contains_redirect_url_to_account_details_when_response_is_not_rejected(
+        self,
+    ) -> None:
+        response = self.create_response(is_rejected=False)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url == self.url_index.get_user_account_details_url()
+
+    def test_that_view_model_contains_no_redirect_url_when_response_is_rejected(
+        self,
+    ) -> None:
+        response = self.create_response(is_rejected=True)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url is None
+
+    def test_that_a_warning_is_displayed_when_response_is_rejected(self) -> None:
+        response = self.create_response(is_rejected=True)
+        assert not self.notifier.warnings
+        self.presenter.render_response(response)
+        assert self.notifier.warnings
+
+    def test_that_no_warning_is_displayed_when_response_is_not_rejected(self) -> None:
+        response = self.create_response(is_rejected=False)
+        assert not self.notifier.warnings
+        self.presenter.render_response(response)
+        assert not self.notifier.warnings
+
+    def test_that_no_info_is_displayed_when_response_is_rejected(self) -> None:
+        response = self.create_response(is_rejected=True)
+        assert not self.notifier.infos
+        self.presenter.render_response(response)
+        assert not self.notifier.infos
+
+    def test_that_an_info_is_displayed_when_response_is_not_rejected(self) -> None:
+        response = self.create_response(is_rejected=False)
+        assert not self.notifier.infos
+        self.presenter.render_response(response)
+        assert self.notifier.infos
+
+    def create_response(self, is_rejected: bool) -> change_user_email_address.Response:
+        return change_user_email_address.Response(is_rejected=is_rejected)


### PR DESCRIPTION
This presenter is intended to be used in the `change_email_address` POST route in `arbeitszeit_flask/user/routes.py` and presents the response of the `ChangeUserEmailAddressUseCase`.

Contributes to #728.

Plan-ID: 371825c0-3112-47cd-9cb0-fea799fad3ee (2x)

