### PR TITLE
List registered hours worked (www layer)

### DIFF
--- a/arbeitszeit_web/www/controllers/list_registered_hours_worked_controller.py
+++ b/arbeitszeit_web/www/controllers/list_registered_hours_worked_controller.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import list_registered_hours_worked
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class ListRegisteredHoursWorkedController:
+    session: Session
+
+    def create_request(self) -> list_registered_hours_worked.Request:
+        current_user_role = self.session.get_user_role()
+        assert current_user_role == UserRole.company
+        current_company = self.session.get_current_user()
+        assert current_company
+        return list_registered_hours_worked.Request(company_id=current_company)

--- a/arbeitszeit_web/www/presenters/list_registered_hours_worked_presenter.py
+++ b/arbeitszeit_web/www/presenters/list_registered_hours_worked_presenter.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import list_registered_hours_worked
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
+
+
+@dataclass
+class RegisteredHoursWorked:
+    hours: str
+    worker_name: str
+    worker_id: str
+    registered_on: str
+
+
+@dataclass
+class ViewModel:
+    registered_hours_worked: list[RegisteredHoursWorked]
+
+
+@dataclass
+class ListRegisteredHoursWorkedPresenter:
+    datetime_formatter: DatetimeFormatter
+
+    def present(self, response: list_registered_hours_worked.Response) -> ViewModel:
+        registered_hours_worked = [
+            RegisteredHoursWorked(
+                hours=str(round(record.hours, 2)),
+                worker_name=record.worker_name,
+                worker_id=str(record.worker_id),
+                registered_on=self.datetime_formatter.format_datetime(
+                    date=record.registered_on,
+                    zone="Europe/Berlin",
+                    fmt="%d.%m.%Y %H:%M",
+                ),
+            )
+            for record in response.registered_hours_worked
+        ]
+        return ViewModel(registered_hours_worked=registered_hours_worked)

--- a/tests/www/controllers/test_list_registered_hours_worked_controller.py
+++ b/tests/www/controllers/test_list_registered_hours_worked_controller.py
@@ -1,0 +1,16 @@
+from arbeitszeit_web.www.controllers.list_registered_hours_worked_controller import (
+    ListRegisteredHoursWorkedController,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class ListRegisteredHoursWorkedControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(ListRegisteredHoursWorkedController)
+
+    def test_that_request_contains_current_company_id(self) -> None:
+        company = self.company_generator.create_company()
+        self.session.login_company(company=company)
+        request = self.controller.create_request()
+        assert request.company_id == company

--- a/tests/www/presenters/test_list_registered_hours_worked_presenter.py
+++ b/tests/www/presenters/test_list_registered_hours_worked_presenter.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.use_cases import list_registered_hours_worked
+from arbeitszeit_web.www.presenters import list_registered_hours_worked_presenter
+from tests.www.base_test_case import BaseTestCase
+
+
+class ListRegisteredHoursWorkedPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(
+            list_registered_hours_worked_presenter.ListRegisteredHoursWorkedPresenter
+        )
+
+    @parameterized.expand(
+        [
+            (0,),
+            (1,),
+            (2,),
+            (3,),
+        ]
+    )
+    def test_view_model_has_same_number_of_registered_hours_worked_as_response(
+        self,
+        number_of_records: int,
+    ) -> None:
+        registered_hours_worked = [
+            self.create_registered_hours_worked() for _ in range(number_of_records)
+        ]
+        response = self.create_use_case_response(
+            registered_hours_worked=registered_hours_worked
+        )
+        view_model = self.presenter.present(response)
+        assert len(view_model.registered_hours_worked) == number_of_records
+
+    @parameterized.expand(
+        [
+            (Decimal("0"), "0.00"),
+            (Decimal("8.0"), "8.00"),
+            (Decimal("8.5"), "8.50"),
+            (Decimal("8.75"), "8.75"),
+            (Decimal("8.123"), "8.12"),
+            (Decimal("8.128"), "8.13"),
+        ]
+    )
+    def test_decimal_hours_from_response_are_rounded_to_two_decimals_and_converted_to_strings(
+        self,
+        hours_in_response: Decimal,
+        expected_string: str,
+    ) -> None:
+        registered_hours_worked = [
+            self.create_registered_hours_worked(hours=hours_in_response)
+        ]
+        response = self.create_use_case_response(
+            registered_hours_worked=registered_hours_worked
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.registered_hours_worked[0].hours == expected_string
+
+    def test_worker_uuid_from_response_is_converted_to_string(self) -> None:
+        worker_id = uuid4()
+        expected_worker_id = str(worker_id)
+        registered_hours_worked = [
+            self.create_registered_hours_worked(worker_id=worker_id)
+        ]
+        response = self.create_use_case_response(
+            registered_hours_worked=registered_hours_worked
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.registered_hours_worked[0].worker_id == expected_worker_id
+
+    def test_worker_name_from_response_is_passed_as_is(self) -> None:
+        worker_name = "Some Name 123"
+        registered_hours_worked = [
+            self.create_registered_hours_worked(worker_name=worker_name)
+        ]
+        response = self.create_use_case_response(
+            registered_hours_worked=registered_hours_worked
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.registered_hours_worked[0].worker_name == worker_name
+
+    def test_registered_on_from_response_is_formatted_correctly(self) -> None:
+        registered_on = datetime(2021, 1, 1, 12, 0)
+        expected_registered_on = self.datetime_service.format_datetime(
+            date=registered_on, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
+        )
+        registered_hours_worked = [
+            self.create_registered_hours_worked(registered_on=registered_on)
+        ]
+        response = self.create_use_case_response(
+            registered_hours_worked=registered_hours_worked
+        )
+        view_model = self.presenter.present(response)
+        assert (
+            view_model.registered_hours_worked[0].registered_on
+            == expected_registered_on
+        )
+
+    def create_registered_hours_worked(
+        self,
+        hours: Decimal = Decimal("8.0"),
+        worker_id: UUID = uuid4(),
+        worker_name: str = "worker_name",
+        registered_on: datetime = datetime(2021, 1, 1),
+    ) -> list_registered_hours_worked.RegisteredHoursWorked:
+        return list_registered_hours_worked.RegisteredHoursWorked(
+            hours=hours,
+            worker_id=worker_id,
+            worker_name=worker_name,
+            registered_on=registered_on,
+        )
+
+    def create_use_case_response(
+        self,
+        registered_hours_worked: list[
+            list_registered_hours_worked.RegisteredHoursWorked
+        ],
+    ) -> list_registered_hours_worked.Response:
+        return list_registered_hours_worked.Response(
+            registered_hours_worked=registered_hours_worked
+        )


### PR DESCRIPTION
**Add ListRegisteredHoursWorkedController** 

This commit adds the `ListRegisteredHoursWorkedController` class, which is responsible for creating a request object for the `list_registered_hours_worked` use case. The controller retrieves the current user role and company from the session and asserts that the current user role is `company`. The company ID is then passed as a parameter to the request object.

See issue #1029 for context.

**Add ListRegisteredHoursWorkedPresenter** 

This commit adds the `ListRegisteredHoursWorkedPresenter` class, which is responsible for presenting the response of the `list_registered_hours_worked` use case. The presenter formats the registered hours worked data, including rounding decimal hours to two decimals and converting worker IDs to strings. This presenter will be used in the web layer to display the registered hours worked information.

See issue #1029 for context.

Plan: 371825c0-3112-47cd-9cb0-fea799fad3ee (4x)