### PR TITLE
Return status code 401 on failed login

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint
+from flask import Response as FlaskResponse
+from flask import flash, redirect, render_template, request, session, url_for
 from flask_login import current_user, login_required
 
 from arbeitszeit.use_cases.confirm_company import ConfirmCompanyUseCase
@@ -117,7 +119,9 @@ def login_member(
         if view_model.redirect_url:
             return redirect(view_model.redirect_url)
         else:
-            render_template("auth/login_member.html", form=login_form)
+            return FlaskResponse(
+                render_template("auth/login_member.html", form=login_form), status=401
+            )
 
     if current_user.is_authenticated:
         if flask_session.is_logged_in_as_member():
@@ -175,7 +179,9 @@ def login_company(
         )
         if view_model.redirect_url:
             return redirect(view_model.redirect_url)
-        return render_template("auth/login_company.html", form=login_form)
+        return FlaskResponse(
+            render_template("auth/login_company.html", form=login_form), status=401
+        )
 
     if current_user.is_authenticated:
         if flask_session.is_logged_in_as_company():
@@ -247,6 +253,9 @@ def login_accountant(
         )
         if view_model.redirect_url is not None:
             return redirect(view_model.redirect_url)
+        return FlaskResponse(
+            render_template("auth/login_accountant.html", form=form), status=401
+        )
     return render_template("auth/login_accountant.html", form=form)
 
 

--- a/tests/flask_integration/test_login_accountant_view.py
+++ b/tests/flask_integration/test_login_accountant_view.py
@@ -29,3 +29,16 @@ class LoginTests(ViewTestCase):
             ),
         )
         self.assertEqual(response.status_code, 302)
+
+    def test_get_401_when_posting_incorrect_credentials(self) -> None:
+        self.accountant_generator.create_accountant(
+            email_address="a@b.c", password="testpassword"
+        )
+        response = self.client.post(
+            self.url,
+            data=dict(
+                email="a@b.c",
+                password="wrongpassword",
+            ),
+        )
+        self.assertEqual(response.status_code, 401)

--- a/tests/flask_integration/test_login_company_view.py
+++ b/tests/flask_integration/test_login_company_view.py
@@ -1,4 +1,43 @@
+from tests.data_generators import CompanyGenerator
+
 from .flask import ViewTestCase
+
+
+class LoginTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/company/login"
+        self.company_generator = self.injector.get(CompanyGenerator)
+
+    def test_get_200_when_accessing_login_view(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_200_when_posting_to_url(self) -> None:
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_redirected_when_posting_correct_credentials(self) -> None:
+        self.company_generator.create_company(email="a@b.c", password="testpassword")
+        response = self.client.post(
+            self.url,
+            data=dict(
+                email="a@b.c",
+                password="testpassword",
+            ),
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_get_401_when_posting_incorrect_credentials(self) -> None:
+        self.company_generator.create_company(email="a@b.c", password="testpassword")
+        response = self.client.post(
+            self.url,
+            data=dict(
+                email="a@b.c",
+                password="wrongpassword",
+            ),
+        )
+        self.assertEqual(response.status_code, 401)
 
 
 class StartViewTests(ViewTestCase):
@@ -22,7 +61,7 @@ class StartViewTests(ViewTestCase):
         )
         assert response.location.endswith(expected_target_url)
 
-    def test_company_can_login_after_having_attempted_to_visit_a_member_route_before(
+    def test_company_can_log_in_after_having_attempted_to_visit_a_member_route_before(
         self,
     ) -> None:
         expected_email = "test@test.test"

--- a/tests/flask_integration/test_login_member_view.py
+++ b/tests/flask_integration/test_login_member_view.py
@@ -1,4 +1,43 @@
+from tests.data_generators import MemberGenerator
+
 from .flask import ViewTestCase
+
+
+class LoginTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/login-member"
+        self.member_generator = self.injector.get(MemberGenerator)
+
+    def test_get_200_when_accessing_login_view(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_200_when_posting_to_url(self) -> None:
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_redirected_when_posting_correct_credentials(self) -> None:
+        self.member_generator.create_member(email="a@b.c", password="testpassword")
+        response = self.client.post(
+            self.url,
+            data=dict(
+                email="a@b.c",
+                password="testpassword",
+            ),
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_get_401_when_posting_incorrect_credentials(self) -> None:
+        self.member_generator.create_member(email="a@b.c", password="testpassword")
+        response = self.client.post(
+            self.url,
+            data=dict(
+                email="a@b.c",
+                password="wrongpassword",
+            ),
+        )
+        self.assertEqual(response.status_code, 401)
 
 
 class StartViewTests(ViewTestCase):
@@ -22,7 +61,7 @@ class StartViewTests(ViewTestCase):
         )
         assert response.location.endswith(expected_target_url)
 
-    def test_member_can_login_after_having_attempted_to_visit_a_company_route_before(
+    def test_member_can_log_in_after_having_attempted_to_visit_a_company_route_before(
         self,
     ) -> None:
         expected_email = "test@test.test"


### PR DESCRIPTION
Before this change we would return 200 when a user (member, company or accountent) provided a wrong password and/or email address on login. Now we return status code 401.

Plan: 371825c0-3112-47cd-9cb0-fea799fad3ee