### PR TITLE
Fix test run warning (sqlalchemy)

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -1664,7 +1664,7 @@ class RegisteredHoursWorkedResult(FlaskQueryResult[records.RegisteredHoursWorked
         members = aliased(models.Member)
         query = self.query.join(
             members, members.id == models.RegisteredHoursWorked.worker
-        ).with_entities(models.RegisteredHoursWorked, models.Member)
+        ).with_entities(models.RegisteredHoursWorked, members)
 
         return FlaskQueryResult(
             db=self.db,


### PR DESCRIPTION
When running our unittests, SQLAlchemy would raise a warning ("SAWarning: SELECT statement has a cartesian product ..."). This gets fixed in this commit.


```
tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py::RegisteredHoursWorkedResultTests::test_that_result_joined_with_worker_has_correct_worker_id
tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py::RegisteredHoursWorkedResultTests::test_that_result_joined_with_worker_has_correct_worker_name_0_name1
tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py::RegisteredHoursWorkedResultTests::test_that_result_joined_with_worker_has_correct_worker_name_1_other_name
  
arbeitszeit_flask/database/repositories.py:53: SAWarning: SELECT statement has a cartesian product between FROM element(s) "member_1", "registered_hours_worked" and FROM element "member".  Apply join condition(s) between each element to resolve.
    element = self.query.first()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 2747 passed, 5 warnings in 149.37s (0:02:29) ======================================
```