### PR TITLE
Fix incorrect merge conflict resolution that rendered the icon useless

### DIFF
--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -88,7 +88,7 @@
                 <button class="button large-button is-primary"
                         type="submit"
                         title="{{ gettext('Accept') }}">
-                  <i class="fas fa-check"></i>
+                        {{ "check"|icon }}
                 </button>
               </form>
               <form action="" method="post">


### PR DESCRIPTION
A picture says more than a thousand words ;)

**Before this fix:**

![image](https://github.com/user-attachments/assets/706e7bfc-9339-4f34-afd3-65d1975e2702)

**After this fix:**

![image](https://github.com/user-attachments/assets/ae3afcb8-e506-49d4-8a0d-0df94bbbe4c6)

I don't now if the margin of the icon, concerning the button size was before #1039 like this. Looks in my opinion a little weird, because the buttons look kind of big. But this type of question is something I would touch in #1035 and transform into something else that looks different from todays status quo anyways. Therefore I would suggest to postpone such styling questions for now.