### PR TITLE
Fix icon path resolution

### DIFF
--- a/arbeitszeit_flask/filters.py
+++ b/arbeitszeit_flask/filters.py
@@ -69,7 +69,7 @@ def icon_filter(
     """
     try:
         # Treat empty icon_name as intentionally set null value
-        if icon_name.strip() == "":
+        if not icon_name.strip():
             return Markup("")
 
         file_name = f"{icon_name}.html"

--- a/arbeitszeit_flask/filters.py
+++ b/arbeitszeit_flask/filters.py
@@ -1,19 +1,21 @@
 import os
+from importlib import resources
 from typing import Callable, Dict
 
 from markupsafe import Markup
 
-ICON_PATH = "arbeitszeit_flask/templates/icons"
+ICON_PACKAGE = "arbeitszeit_flask.templates.icons"
 
 
-def file_reader(file_path: str) -> str:
-    with open(file_path, "r") as file:
-        return file.read()
+def icon_file_reader(file_name: str) -> str:
+    traversable = resources.files(ICON_PACKAGE).joinpath(file_name)
+    with resources.as_file(traversable) as icon_file:
+        return icon_file.read_text(encoding="utf-8")
 
 
 def icon_filter(
     icon_name: str,
-    reader: Callable[[str], str] = file_reader,
+    reader: Callable[[str], str] = icon_file_reader,
     attrs: Dict[str, str] = {},
 ) -> Markup:
     """
@@ -69,8 +71,9 @@ def icon_filter(
         # Treat empty icon_name as intentionally set null value
         if icon_name.strip() == "":
             return Markup("")
-        file_path = os.path.join(ICON_PATH, f"{icon_name}.html")
-        svg_content = reader(file_path)
+
+        file_name = f"{icon_name}.html"
+        svg_content = reader(file_name)
 
         if "<svg" not in svg_content:
             if os.getenv("FLASK_DEBUG") == "1":

--- a/arbeitszeit_flask/filters.py
+++ b/arbeitszeit_flask/filters.py
@@ -8,8 +8,8 @@ ICON_PACKAGE = "arbeitszeit_flask.templates.icons"
 
 
 def icon_file_reader(file_name: str) -> str:
-    traversable = resources.files(ICON_PACKAGE).joinpath(file_name)
-    with resources.as_file(traversable) as icon_file:
+    file_path = resources.files(ICON_PACKAGE).joinpath(file_name)
+    with resources.as_file(file_path) as icon_file:
         return icon_file.read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
This pull request refactors the `icon_filter` function and associated file reader to use `importlib.resources`, to ensure consistent handling of resource files within the app (Flask framework layer). This change addresses the issue of incorrect file paths, especially in production setups where package installation paths can vary.

#### Details
- **Previous Implementation:**
  - The `icon_filter` function relied on a hardcoded relative path to locate SVG files. This approach assumed a specific directory structure, which led to an issue in deployment #1056.
  The conclusion in the above-mentioned issue was that the code attempted to read files via a naive path string, which is not sufficient for use across different environments, causing a `FileNotFoundError` in our production environment.
- **New Implementation:**
  - **Refactor `icon_file_reader`:** 
    - Updated to use `importlib.resources.files` to locate resource files within the package.
    - Leveraged `importlib.resources.as_file` to handle resources properly, ensuring temporary files are managed correctly.
  - **Updated `icon_filter`:**
    - Integrated the refactored `icon_file_reader` to read SVG content from resource files.
    - Maintained the functionality of injecting attributes into SVG content and wrapping it in a `Markup` object for safe embedding in Flask templates.

#### Goals
- **Environment Agnostic:** Ensure the application works correctly in all environments, including production, by abstracting file path details.
- **Maintainability:** Simplifies the codebase using standardized methods from the Python standard library, making it easier to understand and maintain.

#### Testing
- Ran filter tests successfully
- Tested in local development that the function correctly reads SVG files from the package resources.

#### Notes
- This change requires Python 3.9+ due to the use of `importlib.resources.as_file`. We are on 3.11+, therefore should be safe.

Please review the changes and provide feedback. I'm especially keen on a review by @seppeljordan because he knows the production environment best. Thank you!