### PR TITLE
Query param "plan_id" for productive consumption

### DIFF
--- a/arbeitszeit_flask/views/register_productive_consumption.py
+++ b/arbeitszeit_flask/views/register_productive_consumption.py
@@ -26,6 +26,9 @@ class RegisterProductiveConsumptionView:
     @commit_changes
     def GET(self) -> Response:
         form = RegisterProductiveConsumptionForm(request.form)
+        plan_id: str | None = request.args.get("plan_id")
+        if plan_id:
+            form.plan_id_field().set_value(plan_id)
         return FlaskResponse(self._render_template(form), status=200)
 
     @commit_changes

--- a/tests/flask_integration/test_register_productive_consumption_view.py
+++ b/tests/flask_integration/test_register_productive_consumption_view.py
@@ -12,6 +12,13 @@ class CompanyTests(ViewTestCase):
         response = self.client.get("/company/register_productive_consumption")
         self.assertEqual(response.status_code, 200)
 
+    def test_that_plan_id_from_query_string_appears_in_response_html(self) -> None:
+        EXPECTED_PLAN_ID = uuid4()
+        response = self.client.get(
+            f"/company/register_productive_consumption?plan_id={EXPECTED_PLAN_ID}"
+        )
+        assert str(EXPECTED_PLAN_ID) in response.text
+
     def test_that_logged_in_company_receives_200_when_posting_valid_data(
         self,
     ) -> None:


### PR DESCRIPTION
This commit enhances the GET method of `RegisterProductiveConsumptionView` to accept a query parameter "plan_id" and pre-fill the plan_id field of the web form.

#1053