### PR TITLE
Return 400 on rejected productive consumption

### DIFF
--- a/arbeitszeit_flask/views/register_productive_consumption.py
+++ b/arbeitszeit_flask/views/register_productive_consumption.py
@@ -44,7 +44,7 @@ class RegisterProductiveConsumptionView:
         view_model = self.presenter.present(use_case_response)
         if view_model.redirect_url:
             return redirect(view_model.redirect_url)
-        return FlaskResponse(self._render_template(form), status=200)
+        return FlaskResponse(self._render_template(form), status=400)
 
     def _render_template(self, form: RegisterProductiveConsumptionForm) -> str:
         return render_template(

--- a/tests/flask_integration/test_register_productive_consumption_view.py
+++ b/tests/flask_integration/test_register_productive_consumption_view.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from .flask import ViewTestCase
 
 
-class CompanyTests(ViewTestCase):
+class CompanyGetTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.company = self.login_company()
@@ -19,20 +19,51 @@ class CompanyTests(ViewTestCase):
         )
         assert str(EXPECTED_PLAN_ID) in response.text
 
-    def test_that_logged_in_company_receives_200_when_posting_valid_data(
+
+class CompanyPostTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company = self.login_company()
+
+    def test_that_logged_in_company_receives_400_when_posting_non_existing_plan_id(
         self,
     ) -> None:
         response = self.client.post(
             "/company/register_productive_consumption",
             data=dict(plan_id=str(uuid4()), amount=3, type_of_consumption="fixed"),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
 
-    def test_that_logged_in_company_receives_400_when_posting_invalid_data(
+    def test_that_logged_in_company_receives_400_when_posting_invalid_type_of_consumption(
         self,
     ) -> None:
         response = self.client.post(
             "/company/register_productive_consumption",
-            data=dict(plan_id="no uuid", amount=3, type_of_consumption="fixed"),
+            data=dict(
+                plan_id=self.create_plan(), amount=3, type_of_consumption="unknown"
+            ),
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_that_logged_in_company_receives_400_when_posting_incomplete_data(
+        self,
+    ) -> None:
+        response = self.client.post(
+            "/company/register_productive_consumption",
+            data=dict(plan_id=self.create_plan(), amount=3),
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_that_logged_in_company_gets_redirected_when_posting_valid_data(
+        self,
+    ) -> None:
+        response = self.client.post(
+            "/company/register_productive_consumption",
+            data=dict(
+                plan_id=self.create_plan(), amount=3, type_of_consumption="fixed"
+            ),
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def create_plan(self) -> str:
+        return str(self.plan_generator.create_plan())


### PR DESCRIPTION
Before this change we would return code 200 when productive consumptions got rejected due to any of the rejection reasons listed in `RegisterProductiveConsumptionResponse.RejectionReason`.

This has been changed to return 400 instead.

#1053

Plan: 371825c0-3112-47cd-9cb0-fea799fad3ee