### PR TITLE
Implement selection of productive consumption

### DIFF
--- a/arbeitszeit/use_cases/select_productive_consumption.py
+++ b/arbeitszeit/use_cases/select_productive_consumption.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.datetime_service import DatetimeService
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class Request:
+    plan_id: UUID | None
+    amount: int | None
+    consumption_type: ConsumptionType | None
+
+
+@dataclass
+class NoPlanResponse:
+    amount: int | None
+    consumption_type: ConsumptionType | None
+
+
+@dataclass
+class InvalidPlanResponse:
+    amount: int | None
+    consumption_type: ConsumptionType | None
+
+
+@dataclass
+class ValidPlanResponse:
+    plan_id: UUID
+    amount: int | None
+    consumption_type: ConsumptionType | None
+    plan_name: str
+    plan_description: str
+
+
+@dataclass
+class SelectProductiveConsumptionUseCase:
+    database: DatabaseGateway
+    datetime_service: DatetimeService
+
+    def select_productive_consumption(
+        self, request: Request
+    ) -> NoPlanResponse | InvalidPlanResponse | ValidPlanResponse:
+        amount = request.amount
+        consumption_type = request.consumption_type
+        if not request.plan_id:
+            return NoPlanResponse(
+                amount=amount,
+                consumption_type=consumption_type,
+            )
+        plan_result = (
+            self.database.get_plans()
+            .with_id(request.plan_id)
+            .that_will_expire_after(self.datetime_service.now())
+        )
+        if not plan_result:
+            return InvalidPlanResponse(
+                amount=amount,
+                consumption_type=consumption_type,
+            )
+        plan = plan_result.first()
+        assert plan
+        return ValidPlanResponse(
+            plan_id=request.plan_id,
+            amount=amount,
+            consumption_type=consumption_type,
+            plan_name=plan.prd_name,
+            plan_description=plan.description,
+        )

--- a/arbeitszeit_flask/templates/company/register_productive_consumption.html
+++ b/arbeitszeit_flask/templates/company/register_productive_consumption.html
@@ -21,14 +21,35 @@
             </div>
             {% endfor %}
             {% endfor %}
+            {% if view_model.valid_plan_selected is defined and view_model.valid_plan_selected %}
             <form method="post">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% else %}
+            <form method="get">
+            {% endif %}
                 <div class="field">
                     <label class="label">{{ gettext("Plan ID") }}</label>
                     <div class="control">
+                        {% if view_model.valid_plan_selected is defined and view_model.valid_plan_selected %}
+                        {{ form.plan_id(class_="input", readonly=true) }}
+                        {% else %}
                         {{ form.plan_id(class_="input") }}
+                        {% endif %}
                     </div>
                 </div>
+                {% if view_model.valid_plan_selected is defined and view_model.valid_plan_selected %}
+                <div class="notification is-info">
+                    <p>
+                        {{ gettext("Plan ID") }}: {{ view_model.plan_id }}
+                    </p>
+                    <p>
+                        {{ gettext("Plan name") }}: {{ view_model.plan_name }}
+                    </p>
+                    <p>
+                        {{ gettext("Plan description") }}: {{ view_model.plan_description }}
+                    </p>
+                </div>
+                {% endif %}
                 <div class="field">
                     <label class="label">{{ gettext("Amount") }}</label>
                     <div class="control">
@@ -49,7 +70,12 @@
                 </div>
                 <div class="field">
                     <div class="control">
+                        {% if view_model.valid_plan_selected is defined and view_model.valid_plan_selected %}
                         <button class="button is-primary" type="submit">{{ gettext("Register") }}</button>
+                        <a class="button is-light" href="{{ url_for('main_company.register_productive_consumption') }}">{{ gettext("Cancel") }}</a>
+                        {% else %}
+                        <button class="button is-primary" type="submit">{{ gettext("Select") }}</button>
+                        {% endif %}
                     </div>
                 </div>
             </form>

--- a/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
+++ b/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.use_cases.select_productive_consumption import (
+    Request as UseCaseRequest,
+)
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.request import Request
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class SelectProductiveConsumptionController:
+    class InputDataError(Exception):
+        pass
+
+    request: Request
+    notifier: Notifier
+    translator: Translator
+
+    def process_input_data(self) -> UseCaseRequest:
+        plan_id = self._process_plan_id()
+        amount = self._process_amount()
+        consumption_type = self._process_consumption_type()
+        return UseCaseRequest(
+            plan_id=plan_id, amount=amount, consumption_type=consumption_type
+        )
+
+    def _process_plan_id(self) -> UUID | None:
+        plan_id_from_query_string = self.request.query_string().get("plan_id")
+        plan_id_from_form = self.request.get_form("plan_id")
+        if not plan_id_from_query_string and not plan_id_from_form:
+            return None
+        elif plan_id_from_query_string:
+            return self._convert_string_to_uuid(plan_id_from_query_string)
+        else:
+            assert plan_id_from_form
+            return self._convert_string_to_uuid(plan_id_from_form)
+
+    def _convert_string_to_uuid(self, input_string: str) -> UUID:
+        try:
+            return UUID(input_string)
+        except ValueError:
+            self.notifier.display_warning(
+                self.translator.gettext("The provided plan ID is not a valid UUID.")
+            )
+            raise self.InputDataError()
+
+    def _process_amount(self) -> int | None:
+        amount_from_query_string = self.request.query_string().get("amount")
+        amount_from_form = self.request.get_form("amount")
+        if not amount_from_query_string and not amount_from_form:
+            return None
+        elif amount_from_query_string:
+            return self._convert_string_to_int(amount_from_query_string)
+        else:
+            assert amount_from_form
+            return self._convert_string_to_int(amount_from_form)
+
+    def _convert_string_to_int(self, input_string: str) -> int:
+        try:
+            return int(input_string)
+        except ValueError:
+            self.notifier.display_warning(
+                self.translator.gettext("The provided amount is not a valid integer.")
+            )
+            raise self.InputDataError()
+
+    def _process_consumption_type(self) -> ConsumptionType | None:
+        consumption_type_from_query_string = self.request.query_string().get(
+            "type_of_consumption"
+        )
+        consumption_type_from_form = self.request.get_form("type_of_consumption")
+        if not consumption_type_from_query_string and not consumption_type_from_form:
+            return None
+        elif consumption_type_from_query_string:
+            return self._convert_string_to_consumption_type(
+                consumption_type_from_query_string
+            )
+        else:
+            assert consumption_type_from_form
+            return self._convert_string_to_consumption_type(consumption_type_from_form)
+
+    def _convert_string_to_consumption_type(self, input_string: str) -> ConsumptionType:
+        if input_string == "fixed":
+            return ConsumptionType.means_of_prod
+        elif input_string == "liquid":
+            return ConsumptionType.raw_materials
+        else:
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "The provided type of consumption is not valid."
+                )
+            )
+            raise self.InputDataError()

--- a/arbeitszeit_web/www/presenters/select_productive_consumption_presenter.py
+++ b/arbeitszeit_web/www/presenters/select_productive_consumption_presenter.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.use_cases.select_productive_consumption import (
+    InvalidPlanResponse,
+    NoPlanResponse,
+    ValidPlanResponse,
+)
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class SelectProductiveConsumptionPresenter:
+    notifier: Notifier
+    translator: Translator
+
+    @dataclass
+    class ViewModel:
+        valid_plan_selected: bool
+        plan_id: str | None
+        plan_name: str | None
+        plan_description: str | None
+        amount: int | None
+        is_consumption_of_fixed_means: bool
+        status_code: int
+
+    def render_response(
+        self, response: NoPlanResponse | InvalidPlanResponse | ValidPlanResponse
+    ) -> ViewModel:
+        if isinstance(response, NoPlanResponse):
+            return self.ViewModel(
+                valid_plan_selected=False,
+                plan_id=None,
+                plan_name=None,
+                plan_description=None,
+                amount=response.amount,
+                is_consumption_of_fixed_means=response.consumption_type
+                == ConsumptionType.means_of_prod,
+                status_code=200,
+            )
+        if isinstance(response, InvalidPlanResponse):
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "The selected plan does not exist or is not active anymore."
+                )
+            )
+            return self.ViewModel(
+                valid_plan_selected=False,
+                plan_id=None,
+                plan_name=None,
+                plan_description=None,
+                amount=response.amount,
+                is_consumption_of_fixed_means=response.consumption_type
+                == ConsumptionType.means_of_prod,
+                status_code=404,
+            )
+        assert isinstance(response, ValidPlanResponse)
+        return self.ViewModel(
+            valid_plan_selected=True,
+            plan_id=str(response.plan_id),
+            plan_name=response.plan_name,
+            plan_description=response.plan_description,
+            amount=response.amount,
+            is_consumption_of_fixed_means=response.consumption_type
+            == ConsumptionType.means_of_prod,
+            status_code=200,
+        )

--- a/tests/flask_integration/test_register_productive_consumption_view.py
+++ b/tests/flask_integration/test_register_productive_consumption_view.py
@@ -12,12 +12,96 @@ class CompanyGetTests(ViewTestCase):
         response = self.client.get("/company/register_productive_consumption")
         self.assertEqual(response.status_code, 200)
 
-    def test_that_plan_id_from_query_string_appears_in_response_html(self) -> None:
-        EXPECTED_PLAN_ID = uuid4()
+    def test_that_company_receives_error_code_if_plan_id_is_not_a_valid_uuid(
+        self,
+    ) -> None:
         response = self.client.get(
-            f"/company/register_productive_consumption?plan_id={EXPECTED_PLAN_ID}"
+            "/company/register_productive_consumption?plan_id=invalid_uuid"
         )
-        assert str(EXPECTED_PLAN_ID) in response.text
+        assert response.status_code >= 400
+
+    def test_that_company_receives_error_code_if_amount_is_not_a_valid_number(
+        self,
+    ) -> None:
+        response = self.client.get(
+            "/company/register_productive_consumption?amount=invalid_number"
+        )
+        assert response.status_code >= 400
+
+    def test_that_company_receives_error_code_if_type_of_consumption_is_invalid(
+        self,
+    ) -> None:
+        response = self.client.get(
+            "/company/register_productive_consumption?type_of_consumption=invalid"
+        )
+        assert response.status_code >= 400
+
+    def test_that_select_button_is_present_in_response_html_if_no_plan_id_is_given(
+        self,
+    ) -> None:
+        response = self.client.get("/company/register_productive_consumption")
+        assert ">Select</button>" in response.text
+
+    def test_that_register_and_cancel_buttons_are_present_in_response_html_if_plan_id_is_given(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.get(
+            f"/company/register_productive_consumption?plan_id={plan}"
+        )
+        assert ">Register</button>" in response.text
+        assert ">Cancel</a>" in response.text
+
+    def test_that_form_has_get_method_if_no_plan_id_is_given(self) -> None:
+        response = self.client.get("/company/register_productive_consumption")
+        assert '<form method="get"' in response.text
+        assert '<form method="post"' not in response.text
+
+    def test_that_form_has_post_method_if_plan_id_is_given(self) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.get(
+            f"/company/register_productive_consumption?plan_id={plan}"
+        )
+        assert '<form method="post"' in response.text
+        assert '<form method="get"' not in response.text
+
+    def test_that_plan_info_is_present_in_response_html_if_valid_plan_id_is_given_via_url(
+        self,
+    ) -> None:
+        EXPECTED_PLAN_NAME = "Plan name 1234"
+        EXPECTED_PLAN_DESCRIPTION = "Plan description 1234"
+        plan = self.plan_generator.create_plan(
+            product_name=EXPECTED_PLAN_NAME, description=EXPECTED_PLAN_DESCRIPTION
+        )
+        response = self.client.get(
+            f"/company/register_productive_consumption?plan_id={plan}"
+        )
+        assert str(plan) in response.text
+        assert EXPECTED_PLAN_NAME in response.text
+        assert EXPECTED_PLAN_DESCRIPTION in response.text
+
+    def test_that_plan_info_is_present_in_response_html_if_valid_plan_id_is_given_via_form(
+        self,
+    ) -> None:
+        EXPECTED_PLAN_NAME = "Plan name 1234"
+        EXPECTED_PLAN_DESCRIPTION = "Plan description 1234"
+        plan = self.plan_generator.create_plan(
+            product_name=EXPECTED_PLAN_NAME, description=EXPECTED_PLAN_DESCRIPTION
+        )
+        response = self.client.get(
+            "/company/register_productive_consumption",
+            data=dict(plan_id=plan, amount=3, type_of_consumption="fixed"),
+        )
+        assert str(plan) in response.text
+        assert EXPECTED_PLAN_NAME in response.text
+        assert EXPECTED_PLAN_DESCRIPTION in response.text
+
+    def test_that_amount_from_query_string_appears_in_response_html(self) -> None:
+        EXPECTED_AMOUNT = 3
+        response = self.client.get(
+            f"/company/register_productive_consumption?amount={EXPECTED_AMOUNT}"
+        )
+        assert str(EXPECTED_AMOUNT) in response.text
 
 
 class CompanyPostTests(ViewTestCase):

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -259,7 +259,7 @@ class GeneralUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    def test_url_for_registration_of_productive_consumption_leads_to_functional_url(
+    def test_url_for_registration_of_productive_consumption_leads_to_functional_url_without_params_provided(
         self,
     ) -> None:
         self.login_company()
@@ -267,30 +267,21 @@ class GeneralUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    def test_url_for_registration_of_productive_consumption_with_plan_parameter_leads_to_functional_url(
+    def test_url_for_registration_of_productive_consumption_leads_to_functional_url_with_params_provided(
         self,
     ) -> None:
         self.login_company()
-        url = self.url_index.get_register_productive_consumption_url(uuid4())
+        url = self.url_index.get_register_productive_consumption_url()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    def test_url_for_registration_of_productive_consumption_with_amount_parameter_leads_to_functional_url(
+    def test_url_for_registration_of_productive_consumption_leads_to_functional_url(
         self,
     ) -> None:
         self.login_company()
+        plan = self.plan_generator.create_plan()
         url = self.url_index.get_register_productive_consumption_url(
-            plan_id=uuid4(), amount=3
-        )
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-    def test_url_for_registration_of_productive_consumption_with_type_of_consumption_parameter_leads_to_functional_url(
-        self,
-    ) -> None:
-        self.login_company()
-        url = self.url_index.get_register_productive_consumption_url(
-            plan_id=uuid4(),
+            plan_id=plan,
             amount=3,
             consumption_type=ConsumptionType.means_of_prod,
         )

--- a/tests/use_cases/test_select_productive_consumption.py
+++ b/tests/use_cases/test_select_productive_consumption.py
@@ -1,0 +1,108 @@
+from datetime import timedelta
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.use_cases import select_productive_consumption
+from tests.use_cases.base_test_case import BaseTestCase
+
+
+class UseCaseTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(
+            select_productive_consumption.SelectProductiveConsumptionUseCase
+        )
+
+    def test_that_no_plan_response_is_returned_when_no_plan_id_is_provided(self):
+        request = self.create_request()
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.NoPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_does_not_exist(
+        self,
+    ):
+        request = self.create_request(plan_id=uuid4())
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.InvalidPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_is_not_approved(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(approved=False)
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.InvalidPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_is_expired(
+        self,
+    ):
+        self.datetime_service.freeze_time()
+        plan = self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.InvalidPlanResponse)
+
+    def test_that_valid_plan_response_is_returned_when_plan_id_is_provided_and_plan_exists(
+        self,
+    ):
+        plan = self.plan_generator.create_plan()
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.ValidPlanResponse)
+
+    @parameterized.expand([(None,), (0,), (1,), (2,)])
+    def test_that_amount_from_request_is_passed_to_response(self, amount: int | None):
+        request = self.create_request(amount=amount)
+        response = self.use_case.select_productive_consumption(request)
+        assert response.amount == amount
+
+    @parameterized.expand(
+        [(None,), (ConsumptionType.means_of_prod,), (ConsumptionType.raw_materials,)]
+    )
+    def test_that_consumption_type_from_request_is_passed_to_response(
+        self, consumption_type: ConsumptionType | None
+    ):
+        request = self.create_request(consumption_type=consumption_type)
+        response = self.use_case.select_productive_consumption(request)
+        assert response.consumption_type == consumption_type
+
+    def test_that_plan_id_of_valid_plan_response_is_the_same_as_the_provided_plan_id(
+        self,
+    ):
+        plan = self.plan_generator.create_plan()
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert response.plan_id == plan
+
+    @parameterized.expand([("Plan Name 1",), ("Plan Name 2",)])
+    def test_that_plan_name_of_valid_plan_response_is_the_same_as_the_provided_plan_name(
+        self, plan_name: str
+    ):
+        plan = self.plan_generator.create_plan(product_name=plan_name)
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.ValidPlanResponse)
+        assert response.plan_name == plan_name
+
+    @parameterized.expand([("Plan Description 1",), ("Plan Description 2",)])
+    def test_that_plan_description_of_valid_plan_response_is_the_same_as_the_provided_plan_description(
+        self, plan_description: str
+    ):
+        plan = self.plan_generator.create_plan(description=plan_description)
+        request = self.create_request(plan_id=plan)
+        response = self.use_case.select_productive_consumption(request)
+        assert isinstance(response, select_productive_consumption.ValidPlanResponse)
+        assert response.plan_description == plan_description
+
+    def create_request(
+        self,
+        plan_id: UUID | None = None,
+        amount: int | None = None,
+        consumption_type: ConsumptionType | None = None,
+    ) -> select_productive_consumption.Request:
+        return select_productive_consumption.Request(
+            plan_id=plan_id, amount=amount, consumption_type=consumption_type
+        )

--- a/tests/www/controllers/test_select_productive_consumption_controller.py
+++ b/tests/www/controllers/test_select_productive_consumption_controller.py
@@ -1,0 +1,125 @@
+from uuid import uuid4
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit_web.www.controllers.select_productive_consumption_controller import (
+    SelectProductiveConsumptionController,
+)
+from tests.request import FakeRequest
+from tests.www.base_test_case import BaseTestCase
+
+
+class SelectProductiveConsumptionControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.request = self.injector.get(FakeRequest)
+        self.controller = self.injector.get(SelectProductiveConsumptionController)
+
+    def test_that_none_is_returned_when_no_plan_id_is_provided(self) -> None:
+        response = self.controller.process_input_data()
+        assert response.plan_id is None
+
+    def test_that_input_error_is_raised_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        self.request.set_arg("plan_id", "not_a_valid_uuid")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+
+    def test_that_a_warning_is_displayed_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        assert not self.notifier.warnings
+        self.request.set_arg("plan_id", "not_a_valid_uuid")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+        assert self.notifier.warnings
+
+    def test_that_plan_id_from_url_gets_passed_to_response_object(self) -> None:
+        plan_id = uuid4()
+        self.request.set_arg("plan_id", str(plan_id))
+        response = self.controller.process_input_data()
+        assert response.plan_id == plan_id
+
+    def test_that_plan_id_from_form_gets_passed_to_response_object(self) -> None:
+        plan_id = uuid4()
+        self.request.set_form("plan_id", str(plan_id))
+        response = self.controller.process_input_data()
+        assert response.plan_id == plan_id
+
+    def test_that_none_is_returned_when_no_amount_is_provided(self) -> None:
+        response = self.controller.process_input_data()
+        assert response.amount is None
+
+    def test_that_input_error_is_raised_when_amount_is_not_a_valid_number(self) -> None:
+        self.request.set_arg("amount", "not_a_valid_number")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+
+    def test_that_a_warning_is_displayed_when_amount_is_not_a_valid_number(
+        self,
+    ) -> None:
+        assert not self.notifier.warnings
+        self.request.set_arg("amount", "not_a_valid_number")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+        assert self.notifier.warnings
+
+    def test_that_amount_from_url_gets_passed_to_response_object(self) -> None:
+        amount = 10
+        self.request.set_arg("amount", str(amount))
+        response = self.controller.process_input_data()
+        assert response.amount == amount
+
+    def test_that_amount_from_form_gets_passed_to_response_object(self) -> None:
+        amount = 10
+        self.request.set_form("amount", str(amount))
+        response = self.controller.process_input_data()
+        assert response.amount == amount
+
+    def test_that_none_is_returned_when_no_consumption_type_is_provided(self) -> None:
+        response = self.controller.process_input_data()
+        assert response.consumption_type is None
+
+    def test_that_input_error_is_raised_when_consumption_type_is_not_fixed_or_liquid(
+        self,
+    ) -> None:
+        self.request.set_arg("type_of_consumption", "not_fixed_or_liquid")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+
+    def test_that_warning_is_displayed_when_consumption_type_is_not_fixed_or_liquid(
+        self,
+    ) -> None:
+        assert not self.notifier.warnings
+        self.request.set_arg("type_of_consumption", "not_fixed_or_liquid")
+        with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
+            self.controller.process_input_data()
+        assert self.notifier.warnings
+
+    def test_that_fixed_consumption_type_from_url_gets_passed_to_response_object(
+        self,
+    ) -> None:
+        expected_consumption_type = ConsumptionType.means_of_prod
+        self.request.set_arg("type_of_consumption", "fixed")
+        response = self.controller.process_input_data()
+        assert response.consumption_type == expected_consumption_type
+
+    def test_that_liquid_consumption_type_from_url_gets_passed_to_response_object(
+        self,
+    ) -> None:
+        expected_consumption_type = ConsumptionType.raw_materials
+        self.request.set_arg("type_of_consumption", "liquid")
+        response = self.controller.process_input_data()
+        assert response.consumption_type == expected_consumption_type
+
+    def test_that_fixed_consumption_type_from_form_gets_passed_to_response_object(
+        self,
+    ) -> None:
+        expected_consumption_type = ConsumptionType.means_of_prod
+        self.request.set_form("type_of_consumption", "fixed")
+        response = self.controller.process_input_data()
+        assert response.consumption_type == expected_consumption_type
+
+    def test_that_liquid_consumption_type_from_form_gets_passed_to_response_object(
+        self,
+    ) -> None:
+        expected_consumption_type = ConsumptionType.raw_materials
+        self.request.set_form("type_of_consumption", "liquid")
+        response = self.controller.process_input_data()
+        assert response.consumption_type == expected_consumption_type

--- a/tests/www/presenters/test_select_productive_consumption_presenter.py
+++ b/tests/www/presenters/test_select_productive_consumption_presenter.py
@@ -1,0 +1,150 @@
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.records import ConsumptionType
+from arbeitszeit.use_cases import select_productive_consumption
+from arbeitszeit_web.www.presenters.select_productive_consumption_presenter import (
+    SelectProductiveConsumptionPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class PresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(SelectProductiveConsumptionPresenter)
+
+    @parameterized.expand(
+        [
+            (None, None),
+            (5, ConsumptionType.means_of_prod),
+            (10, ConsumptionType.raw_materials),
+        ]
+    )
+    def test_that_no_plan_response_gets_rendered_correctly(
+        self,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+    ):
+        response = self.create_no_plan_response(amount, consumption_type)
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is False
+        assert view_model.plan_id is None
+        assert view_model.plan_name is None
+        assert view_model.plan_description is None
+        assert view_model.amount == amount
+        assert view_model.is_consumption_of_fixed_means == (
+            consumption_type == ConsumptionType.means_of_prod
+        )
+        assert view_model.status_code == 200
+
+    def test_that_warning_is_displayed_when_plan_is_invalid(self):
+        assert not self.notifier.warnings
+        response = self.create_invalid_plan_response(5, ConsumptionType.means_of_prod)
+        self.presenter.render_response(response)
+        assert self.notifier.warnings
+
+    @parameterized.expand(
+        [
+            (None, None),
+            (5, ConsumptionType.means_of_prod),
+            (10, ConsumptionType.raw_materials),
+        ]
+    )
+    def test_that_invalid_plan_response_gets_rendered_correctly(
+        self,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+    ):
+        response = self.create_invalid_plan_response(amount, consumption_type)
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is False
+        assert view_model.plan_id is None
+        assert view_model.plan_name is None
+        assert view_model.plan_description is None
+        assert view_model.amount == amount
+        assert view_model.is_consumption_of_fixed_means == (
+            consumption_type == ConsumptionType.means_of_prod
+        )
+        assert view_model.status_code == 404
+
+    @parameterized.expand(
+        [
+            (
+                uuid4(),
+                5,
+                ConsumptionType.means_of_prod,
+                "Plan Name",
+                "Plan Description",
+            ),
+            (
+                uuid4(),
+                10,
+                ConsumptionType.raw_materials,
+                "Plan Name",
+                "Plan Description",
+            ),
+            (
+                uuid4(),
+                None,
+                ConsumptionType.means_of_prod,
+                "Plan Name",
+                "Plan Description",
+            ),
+            (uuid4(), 5, None, "Plan Name", "Plan Description"),
+        ]
+    )
+    def test_that_valid_plan_response_gets_rendered_correctly(
+        self,
+        plan_id: UUID,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+        plan_name: str,
+        plan_description: str,
+    ):
+        response = self.create_valid_plan_response(
+            plan_id, amount, consumption_type, plan_name, plan_description
+        )
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is True
+        assert view_model.plan_id == str(plan_id)
+        assert view_model.plan_name == plan_name
+        assert view_model.plan_description == plan_description
+        assert view_model.amount == amount
+        assert view_model.is_consumption_of_fixed_means == (
+            consumption_type == ConsumptionType.means_of_prod
+        )
+        assert view_model.status_code == 200
+
+    def create_no_plan_response(
+        self,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+    ) -> select_productive_consumption.NoPlanResponse:
+        return select_productive_consumption.NoPlanResponse(amount, consumption_type)
+
+    def create_invalid_plan_response(
+        self,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+    ) -> select_productive_consumption.InvalidPlanResponse:
+        return select_productive_consumption.InvalidPlanResponse(
+            amount, consumption_type
+        )
+
+    def create_valid_plan_response(
+        self,
+        plan_id: UUID,
+        amount: int | None,
+        consumption_type: ConsumptionType | None,
+        plan_name: str,
+        plan_description: str,
+    ) -> select_productive_consumption.ValidPlanResponse:
+        return select_productive_consumption.ValidPlanResponse(
+            plan_id,
+            amount,
+            consumption_type,
+            plan_name,
+            plan_description,
+        )


### PR DESCRIPTION
This commit creates SelectProductiveConsumptionUseCase, -Presenter and -Controller and uses these in the RegisterProductiveConsumptionView. They are intended to handle the GET part of this view, leaving POST mostly untouched.

It implements a user flow described in issue #1053. New features:

* The user sees some plan info before they have the chance to register consumption.
* The provided plan ID appears as a read-only form field if it is valid.
* There are two new buttons ("Select" and "Cancel").

That is IMO quite a lot of (quite complex) code for a not-so-huge change. Until now it took me around 25 hours (including failed attempts) and I'm still not really happy with the outcome. Perhaps we can discuss in one of our next meetings if this is a necessary consequence of clean architecture (which might be true) or if we can make things easier. I imagine that implementing something like this is even more frustrating for newcomers. 

fixes #1053

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (26x)
