### PR TITLE
Replace workplace email with url

### DIFF
--- a/arbeitszeit/use_cases/get_member_dashboard.py
+++ b/arbeitszeit/use_cases/get_member_dashboard.py
@@ -17,7 +17,7 @@ class Request:
 @dataclass
 class Workplace:
     workplace_name: str
-    workplace_email: str
+    workplace_id: UUID
 
 
 @dataclass
@@ -98,11 +98,11 @@ class GetMemberDashboardUseCase:
         return [
             Workplace(
                 workplace_name=company.name,
-                workplace_email=email.address,
+                workplace_id=company.id,
             )
-            for company, email in self.database_gateway.get_companies()
-            .that_are_workplace_of_member(member)
-            .joined_with_email_address()
+            for company in self.database_gateway.get_companies().that_are_workplace_of_member(
+                member
+            )
         ]
 
     def _get_invites(self, member: UUID) -> List[WorkInvitation]:

--- a/arbeitszeit_flask/templates/member/dashboard.html
+++ b/arbeitszeit_flask/templates/member/dashboard.html
@@ -18,7 +18,7 @@
           {% if view_model.show_workplaces %}
           <ul>
             {% for workplace in view_model.workplaces %}
-            <li>{{ workplace.name }} (<a href="mailto:{{ workplace.email }}">{{ workplace.email }}</a>)</li>
+            <li><a href="{{ workplace.url}}">{{ workplace.name }}</a></li>
             {% endfor %}
           </ul>
           {% endif %}

--- a/arbeitszeit_web/www/presenters/get_member_dashboard_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_member_dashboard_presenter.py
@@ -11,7 +11,7 @@ from arbeitszeit_web.url_index import UrlIndex
 @dataclass
 class Workplace:
     name: str
-    email: str
+    url: str
 
 
 @dataclass
@@ -67,7 +67,9 @@ class GetMemberDashboardPresenter:
             workplaces=[
                 Workplace(
                     name=workplace.workplace_name,
-                    email=workplace.workplace_email,
+                    url=self.url_index.get_company_summary_url(
+                        company_id=workplace.workplace_id
+                    ),
                 )
                 for workplace in use_case_response.workplaces
             ],

--- a/tests/use_cases/test_get_member_dashboard.py
+++ b/tests/use_cases/test_get_member_dashboard.py
@@ -11,17 +11,16 @@ class UseCaseTests(BaseTestCase):
         self.invite_worker_to_company = self.injector.get(InviteWorkerToCompanyUseCase)
         self.member = self.member_generator.create_member()
 
-    def test_that_correct_workplace_email_is_shown(self):
-        self.company_generator.create_company_record(
-            email="companyname@mail.com",
+    def test_that_correct_workplace_id_is_shown(self):
+        company = self.company_generator.create_company(
             workers=[self.member],
         )
         request = get_member_dashboard.Request(member=self.member)
         member_info = self.use_case.get_member_dashboard(request)
-        assert member_info.workplaces[0].workplace_email == "companyname@mail.com"
+        assert member_info.workplaces[0].workplace_id == company
 
     def test_that_correct_workplace_name_is_shown(self):
-        self.company_generator.create_company_record(
+        self.company_generator.create_company(
             name="SomeCompanyNameXY",
             workers=[self.member],
         )

--- a/tests/www/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_member_dashboard_presenter.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from uuid import UUID, uuid4
 
 from dateutil import tz
+from parameterized import parameterized
 
 from arbeitszeit.use_cases import get_member_dashboard
 from arbeitszeit_web.session import UserRole
@@ -38,7 +39,7 @@ class GetMemberDashboardPresenterTests(BaseTestCase):
         response = self.get_response(
             workplaces=[
                 get_member_dashboard.Workplace(
-                    workplace_name="workplace_name", workplace_email="workplace@cp.org"
+                    workplace_name="workplace_name", workplace_id=uuid4()
                 ),
             ]
         )
@@ -46,11 +47,42 @@ class GetMemberDashboardPresenterTests(BaseTestCase):
         self.assertTrue(presentation.show_workplaces)
         self.assertTrue(presentation.workplaces)
 
+    @parameterized.expand(
+        [
+            ("Workplace Name 1",),
+            ("Workplace Name 2",),
+        ]
+    )
+    def test_that_the_correct_name_of_workplace_is_shown(self, workplace_name: str):
+        response = self.get_response(
+            workplaces=[
+                get_member_dashboard.Workplace(
+                    workplace_name=workplace_name, workplace_id=uuid4()
+                ),
+            ]
+        )
+        presentation = self.presenter.present(response)
+        assert presentation.workplaces[0].name == workplace_name
+
+    def test_that_url_of_workplace_leads_to_company_summary_page(self):
+        workplace_id = uuid4()
+        response = self.get_response(
+            workplaces=[
+                get_member_dashboard.Workplace(
+                    workplace_name="workplace_name", workplace_id=workplace_id
+                ),
+            ]
+        )
+        presentation = self.presenter.present(response)
+        assert presentation.workplaces[0].url == self.url_index.get_company_summary_url(
+            company_id=workplace_id
+        )
+
     def test_that_work_registration_info_is_not_shown_when_worker_is_employed(self):
         response = self.get_response(
             workplaces=[
                 get_member_dashboard.Workplace(
-                    workplace_name="workplace_name", workplace_email="workplace@cp.org"
+                    workplace_name="workplace_name", workplace_id=uuid4()
                 ),
             ]
         )


### PR DESCRIPTION
_To be reviewed after merge of https://github.com/ida-arbeitszeit/arbeitszeitapp/pull/1079_

**Replace workplace email with url** 

Members have on their dashboard a list of their workplaces. Before this commit, the email address of these workplaces were shown. Now, a link to the company summary page of their workplace is shown instead (where the email address can be seen).

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (1x)

![image](https://github.com/user-attachments/assets/6f864a13-5390-4e93-b191-f8a9149b5657)
