### PR TITLE
Prevent re-submitting form

### DIFF
--- a/arbeitszeit_web/www/presenters/register_hours_worked_presenter.py
+++ b/arbeitszeit_web/www/presenters/register_hours_worked_presenter.py
@@ -30,7 +30,7 @@ class RegisterHoursWorkedPresenter:
             self.notifier.display_info(
                 self.translator.gettext("Labour hours successfully registered")
             )
-            return 200
+            return 302
 
     def present_controller_warnings(
         self, controller_rejection: ControllerRejection

--- a/tests/flask_integration/test_register_hours_worked_view.py
+++ b/tests/flask_integration/test_register_hours_worked_view.py
@@ -18,14 +18,14 @@ class AuthenticatedCompanyTests(ViewTestCase):
         response = self.client.post(self.url)
         self.assertEqual(response.status_code, 400)
 
-    def test_company_gets_200_when_posting_correct_data(self) -> None:
+    def test_company_gets_302_when_posting_correct_data(self) -> None:
         worker = self.member_generator.create_member()
         self.company_manager.add_worker_to_company(self.company.id, worker)
         response = self.client.post(
             self.url,
             data=dict(member_id=str(worker), amount="10"),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
     def test_company_gets_404_when_posting_incorrect_data_with_worker_not_in_company(
         self,

--- a/tests/www/presenters/test_register_hours_worked_presenter.py
+++ b/tests/www/presenters/test_register_hours_worked_presenter.py
@@ -41,9 +41,9 @@ class PresentUseCaseResponseTests(BaseTestCase):
         self.assertTrue(self.notifier.infos)
         self.assertFalse(self.notifier.warnings)
 
-    def test_presenter_returns_status_200_if_use_case_response_is_successfull(self):
+    def test_presenter_returns_status_302_if_use_case_response_is_successfull(self):
         code = self.presenter.present_use_case_response(SUCCESS_USE_CASE_RESPONSE)
-        self.assertEqual(code, 200)
+        self.assertEqual(code, 302)
 
     def test_that_the_user_is_notified_about_success(self) -> None:
         self.presenter.present_use_case_response(SUCCESS_USE_CASE_RESPONSE)


### PR DESCRIPTION
This commit prevents re-submitting the post form in `/company/register_hours_worked` when using back-button in browser.

Fixes #1054