### PR TITLE
Delete @commit_changes decorator from GET routes

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -266,7 +266,6 @@ class request_cooperation(RequestCooperationView): ...
 
 
 @CompanyRoute("/my_cooperations", methods=["GET"])
-@commit_changes
 def my_cooperations(
     list_coordinations: ListCoordinationsOfCompany,
     show_company_cooperations: ShowCompanyCooperationsUseCase,

--- a/arbeitszeit_flask/views/register_hours_worked_view.py
+++ b/arbeitszeit_flask/views/register_hours_worked_view.py
@@ -23,7 +23,6 @@ class RegisterHoursWorkedView:
     presenter: RegisterHoursWorkedPresenter
     list_workers: ListWorkers
 
-    @commit_changes
     def GET(self) -> Response:
         return self.create_response(status=200)
 

--- a/arbeitszeit_flask/views/register_private_consumption.py
+++ b/arbeitszeit_flask/views/register_private_consumption.py
@@ -26,7 +26,6 @@ class RegisterPrivateConsumptionView:
     controller: RegisterPrivateConsumptionController
     presenter: RegisterPrivateConsumptionPresenter
 
-    @commit_changes
     def GET(self) -> Response:
         form = RegisterPrivateConsumptionForm(request.form)
         amount: Optional[str] = request.args.get("amount")

--- a/arbeitszeit_flask/views/register_productive_consumption.py
+++ b/arbeitszeit_flask/views/register_productive_consumption.py
@@ -23,7 +23,6 @@ class RegisterProductiveConsumptionView:
     register_productive_consumption: RegisterProductiveConsumption
     presenter: RegisterProductiveConsumptionPresenter
 
-    @commit_changes
     def GET(self) -> Response:
         form = RegisterProductiveConsumptionForm(request.form)
         plan_id: str | None = request.args.get("plan_id")

--- a/arbeitszeit_flask/views/request_cooperation_view.py
+++ b/arbeitszeit_flask/views/request_cooperation_view.py
@@ -29,7 +29,6 @@ class RequestCooperationView:
     controller: RequestCooperationController
     presenter: RequestCooperationPresenter
 
-    @commit_changes
     def GET(self) -> Response:
         list_plans_view_model = self._get_list_plans_view_model()
         return Response(

--- a/arbeitszeit_flask/views/request_coordination_transfer_view.py
+++ b/arbeitszeit_flask/views/request_coordination_transfer_view.py
@@ -24,7 +24,6 @@ class RequestCoordinationTransferView:
     controller: RequestCoordinationTransferController
     use_case: RequestCoordinationTransferUseCase
 
-    @commit_changes
     def GET(self, coop_id: UUID) -> types.Response:
         form = RequestCoordinationTransferForm()
         form.cooperation_field().set_value(str(coop_id))

--- a/arbeitszeit_flask/views/show_coordination_transfer_request_view.py
+++ b/arbeitszeit_flask/views/show_coordination_transfer_request_view.py
@@ -31,7 +31,6 @@ class ShowCoordinationTransferRequestView:
     accept_use_case: AcceptCoordinationTransferUseCase
     accept_presenter: AcceptCoordinationTransferPresenter
 
-    @commit_changes
     def GET(self, transfer_request: UUID) -> types.Response:
         details_uc_response = self.details_use_case.get_details(
             request=GetCoordinationTransferRequestDetailsUseCase.Request(

--- a/arbeitszeit_flask/views/signup_accountant_view.py
+++ b/arbeitszeit_flask/views/signup_accountant_view.py
@@ -20,7 +20,6 @@ class SignupAccountantView:
     presenter: RegisterAccountantPresenter
     use_case: RegisterAccountantUseCase
 
-    @commit_changes
     def GET(self, token: str) -> types.Response:
         return Response(
             response=render_template(

--- a/arbeitszeit_flask/views/signup_company_view.py
+++ b/arbeitszeit_flask/views/signup_company_view.py
@@ -24,7 +24,6 @@ class SignupCompanyView:
     presenter: RegisterCompanyPresenter
     flask_session: FlaskSession
 
-    @commit_changes
     def GET(self) -> Response:
         register_form = RegisterForm(request.form)
         if current_user.is_authenticated:

--- a/arbeitszeit_flask/views/signup_member_view.py
+++ b/arbeitszeit_flask/views/signup_member_view.py
@@ -24,7 +24,6 @@ class SignupMemberView:
     register_member_presenter: RegisterMemberPresenter
     flask_session: FlaskSession
 
-    @commit_changes
     def GET(self):
         if current_user.is_authenticated:
             if self.flask_session.is_logged_in_as_member():


### PR DESCRIPTION
This commit addresses nearly all GET routes listed in issue #1084, only `EndCooperationView` in `arbeitszeit_flask/views/end_cooperation_view.py` needs some more thorough refactoring.

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (1x)