### PR TITLE
Improve worker invitation

### DIFF
--- a/arbeitszeit/use_cases/invite_worker_to_company.py
+++ b/arbeitszeit/use_cases/invite_worker_to_company.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from enum import Enum, auto
 from uuid import UUID
 
 from arbeitszeit.email_notifications import EmailSender, WorkerInvitation
@@ -17,30 +17,55 @@ class InviteWorkerToCompanyUseCase:
 
     @dataclass
     class Response:
-        is_success: bool
-        invite_id: Optional[UUID] = None
+        class RejectionReason(Enum):
+            WORKER_NOT_FOUND = auto()
+            COMPANY_NOT_FOUND = auto()
+            WORKER_ALREADY_WORKS_FOR_COMPANY = auto()
+            INVITATION_ALREADY_ISSUED = auto()
+
+        worker: UUID
+        invite_id: UUID | None = None
+        rejection_reason: RejectionReason | None = None
 
     database_gateway: DatabaseGateway
     email_sender: EmailSender
 
-    def __call__(self, request: Request) -> Response:
+    def invite_worker(self, request: Request) -> Response:
         addressee = self.database_gateway.get_members().with_id(request.worker).first()
         if addressee is None:
-            return self.Response(is_success=False)
+            return self.Response(
+                worker=request.worker,
+                rejection_reason=self.Response.RejectionReason.WORKER_NOT_FOUND,
+            )
         if not self.database_gateway.get_companies().with_id(request.company):
-            return self.Response(is_success=False)
+            return self.Response(
+                worker=request.worker,
+                rejection_reason=self.Response.RejectionReason.COMPANY_NOT_FOUND,
+            )
+        if (
+            self.database_gateway.get_members()
+            .with_id(request.worker)
+            .working_at_company(request.company)
+        ):
+            return self.Response(
+                worker=request.worker,
+                rejection_reason=self.Response.RejectionReason.WORKER_ALREADY_WORKS_FOR_COMPANY,
+            )
         if (
             self.database_gateway.get_company_work_invites()
             .addressing(request.worker)
             .issued_by(request.company)
         ):
-            return self.Response(is_success=False)
+            return self.Response(
+                worker=request.worker,
+                rejection_reason=self.Response.RejectionReason.INVITATION_ALREADY_ISSUED,
+            )
         else:
             invite = self.database_gateway.create_company_work_invite(
                 request.company, request.worker
             )
             self.notify_member_about_invitation(member=invite.member, invite=invite.id)
-            return self.Response(is_success=True, invite_id=invite.id)
+            return self.Response(worker=request.worker, invite_id=invite.id)
 
     def notify_member_about_invitation(self, member: UUID, invite: UUID) -> None:
         record = (

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -290,18 +290,6 @@ class CreateDraftForm(Form):
         return WtFormField(form=self, field_name="productive_or_public")
 
 
-class InviteWorkerToCompanyForm(Form):
-    member_id = StringField(
-        validators=[
-            FieldMustExist(message=trans.lazy_gettext("Required")),
-        ],
-        render_kw={"placeholder": trans.lazy_gettext("Member ID")},
-    )
-
-    def get_worker_id(self) -> str:
-        return self.data["member_id"]
-
-
 class CreateCooperationForm(Form):
     name = StringField(
         render_kw={"placeholder": trans.lazy_gettext("Name")},

--- a/arbeitszeit_flask/templates/company/invite_worker_to_company.html
+++ b/arbeitszeit_flask/templates/company/invite_worker_to_company.html
@@ -13,11 +13,24 @@
       <div class="content">
         <h1 class="title">{{ gettext("Invite worker") }}</h1>
         <form method="post">
-          <div class="field has-addons has-addons-centered">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            {{ form.member_id(class_="input") }}
-            <button class="button is-primary">{{ gettext("Invite") }}</button>
-          </div>
+            <input 
+            class="input"
+            id="worker_id"
+            name="worker_id"
+            value="{{ form.worker_id_value }}"
+            placeholder="{{ gettext('Member ID') }}"
+            type="text"
+            required
+            >
+            {% if form.worker_id_errors %}
+            <ul class="has-text-danger has-text-left">
+              {% for error in form.worker_id_errors %}
+              <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+            <button class="button is-primary" type="submit">{{ gettext("Invite") }}</button>
         </form>
       </div>
 

--- a/arbeitszeit_web/forms.py
+++ b/arbeitszeit_web/forms.py
@@ -92,3 +92,9 @@ class RegisterPrivateConsumptionForm:
     amount_value: str
     plan_id_errors: list[str] = field(default_factory=list)
     amount_errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class InviteWorkerToCompanyForm:
+    worker_id_value: str
+    worker_id_errors: list[str] = field(default_factory=list)

--- a/arbeitszeit_web/www/presenters/invite_worker_to_company_presenter.py
+++ b/arbeitszeit_web/www/presenters/invite_worker_to_company_presenter.py
@@ -1,28 +1,53 @@
 from dataclasses import dataclass
-from typing import List
 
 from arbeitszeit.use_cases.invite_worker_to_company import InviteWorkerToCompanyUseCase
+from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.translator import Translator
 
 
 @dataclass
 class ViewModel:
-    notifications: List[str]
+    status_code: int
+    worker: str
 
 
 @dataclass
 class InviteWorkerToCompanyPresenter:
     translator: Translator
+    notifier: Notifier
 
     def present(
         self, use_case_response: InviteWorkerToCompanyUseCase.Response
     ) -> ViewModel:
-        if use_case_response.is_success:
-            notifications = [
-                self.translator.gettext("Worker has been invited successfully.")
-            ]
-        else:
-            notifications = [self.translator.gettext("Worker could not be invited.")]
-        return ViewModel(
-            notifications=notifications,
-        )
+        match use_case_response.rejection_reason:
+            case InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_NOT_FOUND:
+                self.notifier.display_warning(
+                    self.translator.gettext("Worker could not be found.")
+                )
+                return ViewModel(status_code=400, worker=str(use_case_response.worker))
+            case (
+                InviteWorkerToCompanyUseCase.Response.RejectionReason.COMPANY_NOT_FOUND
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Company could not be found.")
+                )
+                return ViewModel(status_code=400, worker=str(use_case_response.worker))
+            case (
+                InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_ALREADY_WORKS_FOR_COMPANY
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Worker already works for the company.")
+                )
+                return ViewModel(status_code=400, worker=str(use_case_response.worker))
+            case (
+                InviteWorkerToCompanyUseCase.Response.RejectionReason.INVITATION_ALREADY_ISSUED
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Invitation has already been issued.")
+                )
+                return ViewModel(status_code=400, worker=str(use_case_response.worker))
+            case None:
+                self.notifier.display_info(
+                    self.translator.gettext("Worker has been invited successfully.")
+                )
+                return ViewModel(status_code=302, worker=str(use_case_response.worker))

--- a/tests/flask_integration/test_company_work_invite_view.py
+++ b/tests/flask_integration/test_company_work_invite_view.py
@@ -11,7 +11,7 @@ class AuthenticatedTests(ViewTestCase):
         super().setUp()
         self.member = self.login_member()
         self.company_generator = self.injector.get(CompanyGenerator)
-        self.invite_use_case = self.injector.get(InviteWorkerToCompanyUseCase)
+        self.use_case = self.injector.get(InviteWorkerToCompanyUseCase)
 
     def test_get_request_for_existing_invite_yields_status_200(self) -> None:
         invite_id = self.invite_member()
@@ -35,7 +35,7 @@ class AuthenticatedTests(ViewTestCase):
 
     def invite_member(self) -> UUID:
         company = self.company_generator.create_company_record()
-        response = self.invite_use_case(
+        response = self.use_case.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company.id,
                 self.member,

--- a/tests/flask_integration/test_invite_worker_to_company_view.py
+++ b/tests/flask_integration/test_invite_worker_to_company_view.py
@@ -1,44 +1,57 @@
+from uuid import uuid4
+
+from parameterized import parameterized
+
 from tests.company import CompanyManager
 
 from .flask import ViewTestCase
 
+URL = "/company/invite_worker_to_company"
+
 
 class AnonymousUserTests(ViewTestCase):
-    def test_get_redirected_when_no_logged_in(self) -> None:
-        response = self.client.get("/company/invite_worker_to_company")
+    def test_get_redirected_when_not_logged_in(self) -> None:
+        response = self.client.get(URL)
         self.assertEqual(response.status_code, 302)
 
 
 class InviteWorkerToCompanyTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company()
-        self.company_manager = self.injector.get(CompanyManager)
 
-    def test_get_200_when_logged_in_as_company(self) -> None:
-        response = self.client.get("/company/invite_worker_to_company")
-        self.assertEqual(response.status_code, 200)
+    def test_get_yields_200_when_logged_in_as_company(self) -> None:
+        self.login_company()
+        response = self.client.get(URL)
+        assert response.status_code == 200
 
-    def test_that_get_response_contains_worker_names(self) -> None:
-        expected_member_name = "test member 123"
-        worker = self.member_generator.create_member(name=expected_member_name)
-        self.company_manager.add_worker_to_company(self.company.id, worker)
-        response = self.client.get("/company/invite_worker_to_company")
-        self.assertIn(expected_member_name, response.data.decode("utf-8"))
+    @parameterized.expand(
+        [
+            ("test member 123",),
+            ("test member 456",),
+        ]
+    )
+    def test_that_get_response_contains_worker_name_of_worker_that_works_there(
+        self, worker_name: str
+    ) -> None:
+        company = self.login_company()
+        company_manager = self.injector.get(CompanyManager)
+        worker = self.member_generator.create_member(name=worker_name)
+        company_manager.add_worker_to_company(company.id, worker)
+        response = self.client.get(URL)
+        assert worker_name in response.text
 
     def test_post_yields_400_if_no_post_data_was_provided(self) -> None:
-        response = self.client.post("/company/invite_worker_to_company")
-        self.assertEqual(response.status_code, 400)
-
-    def test_post_yields_200_if_correct_data_was_provided(self) -> None:
-        member = self.member_generator.create_member()
-        response = self.client.post(
-            "/company/invite_worker_to_company", data={"member_id": str(member)}
-        )
-        self.assertEqual(response.status_code, 200)
+        self.login_company()
+        response = self.client.post(URL)
+        assert response.status_code == 400
 
     def test_post_yields_400_with_incorrect_uuid(self) -> None:
-        response = self.client.post(
-            "/company/invite_worker_to_company", data={"member_id": "abc"}
-        )
-        self.assertEqual(response.status_code, 400)
+        self.login_company()
+        response = self.client.post(URL, data={"worker_id": str(uuid4())})
+        assert response.status_code == 400
+
+    def test_post_yields_302_if_correct_data_was_provided(self) -> None:
+        worker = self.member_generator.create_member()
+        self.login_company()
+        response = self.client.post(URL, data={"worker_id": str(worker)})
+        assert response.status_code == 302

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -86,7 +86,9 @@ class GeneralUrlIndexTests(ViewTestCase):
         super().setUp()
         self.plan_generator = self.injector.get(PlanGenerator)
         self.url_index = self.injector.get(GeneralUrlIndex)
-        self.invite_worker_to_company = self.injector.get(InviteWorkerToCompanyUseCase)
+        self.invite_worker_to_company_use_case = self.injector.get(
+            InviteWorkerToCompanyUseCase
+        )
         self.cooperation_generator = self.injector.get(CooperationGenerator)
         self.invite_accountant_use_case = self.injector.get(
             SendAccountantRegistrationTokenUseCase
@@ -230,7 +232,7 @@ class GeneralUrlIndexTests(ViewTestCase):
 
     def _create_invite(self, member: UUID) -> UUID:
         company = self.company_generator.create_company_record()
-        response = self.invite_worker_to_company(
+        response = self.invite_worker_to_company_use_case.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=company.id,
                 worker=member,

--- a/tests/use_cases/test_answer_company_work_invite.py
+++ b/tests/use_cases/test_answer_company_work_invite.py
@@ -218,7 +218,7 @@ class AnwerCompanyWorkInviteTests(BaseTestCase):
         self.assertIsNone(response.company_name)
 
     def _invite_worker(self) -> UUID:
-        invite_response = self.invite_worker_to_company(
+        invite_response = self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 self.company.id,
                 self.member,

--- a/tests/use_cases/test_get_member_dashboard.py
+++ b/tests/use_cases/test_get_member_dashboard.py
@@ -48,7 +48,7 @@ class UseCaseTests(BaseTestCase):
 
     def test_invites_are_shown_when_worker_was_previously_invited(self):
         inviting_company = self.company_generator.create_company_record()
-        self.invite_worker_to_company(
+        self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
         request = get_member_dashboard.Request(member=self.member)
@@ -57,7 +57,7 @@ class UseCaseTests(BaseTestCase):
 
     def test_show_id_of_company_that_sent_the_invite(self):
         inviting_company = self.company_generator.create_company_record()
-        self.invite_worker_to_company(
+        self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
         request = get_member_dashboard.Request(member=self.member)
@@ -66,7 +66,7 @@ class UseCaseTests(BaseTestCase):
 
     def test_show_name_of_company_that_sent_the_invite(self):
         inviting_company = self.company_generator.create_company_record()
-        self.invite_worker_to_company(
+        self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
         request = get_member_dashboard.Request(member=self.member)
@@ -75,7 +75,7 @@ class UseCaseTests(BaseTestCase):
 
     def test_show_correct_invite_id(self):
         inviting_company = self.company_generator.create_company_record()
-        invite_response = self.invite_worker_to_company(
+        invite_response = self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
         request = get_member_dashboard.Request(member=self.member)

--- a/tests/use_cases/test_show_company_work_invite.py
+++ b/tests/use_cases/test_show_company_work_invite.py
@@ -33,11 +33,11 @@ class TestExistingMemberWithNonMatchingInvite(TestCase):
         self.use_case = self.injector.get(ShowCompanyWorkInviteDetailsUseCase)
         self.member_generator = self.injector.get(MemberGenerator)
         self.company_generator = self.injector.get(CompanyGenerator)
-        self.invite_worker = self.injector.get(InviteWorkerToCompanyUseCase)
+        self.invite_worker_use_case = self.injector.get(InviteWorkerToCompanyUseCase)
         self.invited_member = self.member_generator.create_member()
         self.other_member = self.member_generator.create_member()
         self.company = self.company_generator.create_company_record()
-        invite_response = self.invite_worker(
+        invite_response = self.invite_worker_use_case.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company.id,
                 worker=self.invited_member,
@@ -83,7 +83,7 @@ class TestExistingMemberWithMatchingInvite(TestCase):
         self.company = self.company_generator.create_company_record(
             name=self.expected_company_name
         )
-        invite_response = self.invite_worker(
+        invite_response = self.invite_worker.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company.id,
                 worker=self.member,

--- a/tests/use_cases/test_show_work_invites.py
+++ b/tests/use_cases/test_show_work_invites.py
@@ -21,7 +21,7 @@ class ShowWorkInvitesTests(BaseTestCase):
         self.assertFalse(response.invites)
 
     def test_invites_are_shown_when_worker_was_previously_invited(self) -> None:
-        self.invite_worker_to_company(
+        self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company,
                 worker=self.member,
@@ -35,7 +35,7 @@ class ShowWorkInvitesTests(BaseTestCase):
         self.assertTrue(response.invites)
 
     def test_show_which_company_sent_the_invite(self) -> None:
-        self.invite_worker_to_company(
+        self.invite_worker_to_company.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company,
                 worker=self.member,

--- a/tests/www/presenters/test_invite_worker_to_company.py
+++ b/tests/www/presenters/test_invite_worker_to_company.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from arbeitszeit.use_cases.invite_worker_to_company import InviteWorkerToCompanyUseCase
 from arbeitszeit_web.www.presenters.invite_worker_to_company_presenter import (
     InviteWorkerToCompanyPresenter,
@@ -10,22 +12,133 @@ class InviteWorkerToCompanyPresenterTests(BaseTestCase):
         super().setUp()
         self.presenter = self.injector.get(InviteWorkerToCompanyPresenter)
 
-    def test_successfule_invitation_response_displays_proper_notification(self) -> None:
+    def test_when_worker_is_not_found_code_400_is_presented(self):
         response = InviteWorkerToCompanyUseCase.Response(
-            is_success=True,
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_NOT_FOUND,
         )
         view_model = self.presenter.present(response)
-        self.assertIn(
-            self.translator.gettext("Worker has been invited successfully."),
-            view_model.notifications,
+        assert view_model.worker == str(response.worker)
+
+    def test_when_worker_is_not_found_worker_id_from_response_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_NOT_FOUND,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.worker == str(response.worker)
+
+    def test_when_worker_is_not_found_warning_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_NOT_FOUND,
+        )
+        self.presenter.present(response)
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Worker could not be found."
         )
 
-    def test_unsuccessful_invitation_response_displays_proper_message(self) -> None:
+    def test_when_company_is_not_found_code_400_is_presented(self):
         response = InviteWorkerToCompanyUseCase.Response(
-            is_success=False,
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.COMPANY_NOT_FOUND,
         )
         view_model = self.presenter.present(response)
-        self.assertIn(
-            self.translator.gettext("Worker could not be invited."),
-            view_model.notifications,
+        assert view_model.status_code == 400
+
+    def test_when_company_is_not_found_worker_id_from_response_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.COMPANY_NOT_FOUND,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.worker == str(response.worker)
+
+    def test_when_company_is_not_found_warning_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.COMPANY_NOT_FOUND,
+        )
+        self.presenter.present(response)
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Company could not be found."
+        )
+
+    def test_when_worker_works_already_for_company_code_400_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_ALREADY_WORKS_FOR_COMPANY,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.status_code == 400
+
+    def test_when_worker_works_already_for_company_worker_id_from_response_is_presented(
+        self,
+    ):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_ALREADY_WORKS_FOR_COMPANY,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.worker == str(response.worker)
+
+    def test_when_worker_works_already_for_company_warning_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.WORKER_ALREADY_WORKS_FOR_COMPANY,
+        )
+        self.presenter.present(response)
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Worker already works for the company."
+        )
+
+    def test_when_invitation_is_already_issued_code_400_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.INVITATION_ALREADY_ISSUED,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.status_code == 400
+
+    def test_when_invitation_is_already_issued_worker_id_from_response_is_presented(
+        self,
+    ):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.INVITATION_ALREADY_ISSUED,
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.worker == str(response.worker)
+
+    def test_when_invitation_is_already_issued_warning_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+            rejection_reason=InviteWorkerToCompanyUseCase.Response.RejectionReason.INVITATION_ALREADY_ISSUED,
+        )
+        self.presenter.present(response)
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Invitation has already been issued."
+        )
+
+    def test_when_worker_is_invited_code_302_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.status_code == 302
+
+    def test_when_worker_is_invited_worker_id_from_response_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.worker == str(response.worker)
+
+    def test_when_worker_is_invited_info_is_presented(self):
+        response = InviteWorkerToCompanyUseCase.Response(
+            worker=uuid4(),
+        )
+        self.presenter.present(response)
+        assert self.notifier.infos[0] == self.translator.gettext(
+            "Worker has been invited successfully."
         )


### PR DESCRIPTION
After this change the `InviteWorkerToCompanyUseCase` returns explicit rejection reasons to improve the error handling in the presenter.

The flask-layer view  `InviteWorkerToCompanyView` has been changed to redirect on successful POST request instead of returning 200.

Should fix all problems described in #1081.

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (6x)