### PR TITLE
Fix bug in PlanQueryResult

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -85,7 +85,9 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
         if not ascending:
             ordering = ordering.desc()
         return self._with_modified_query(
-            lambda query: self.query.join(models.Company).order_by(func.lower(ordering))
+            lambda query: query.join(models.Company)
+            .order_by(func.lower(ordering))
+            .group_by(models.Plan.id, models.Company.id)
         )
 
     def with_id_containing(self, query: str) -> Self:

--- a/tests/flask_integration/database_gateway_impl/test_plan_results.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_results.py
@@ -736,6 +736,18 @@ class JoinedWithPlannerAndCooperationAndCooperatingPlansTests(FlaskTestCase):
         for v in results:
             assert not v[2]
 
+    def test_that_it_is_possible_to_order_by_planner_name_and_join(self) -> None:
+        self.plan_generator.create_plan()
+        self.plan_generator.create_plan()
+        results = (
+            self.database_gateway.get_plans()
+            .ordered_by_planner_name()
+            .joined_with_planner_and_cooperation_and_cooperating_plans(
+                self.datetime_service.now()
+            )
+        )
+        results.first()
+
 
 class JoinedWithCooperationTests(FlaskTestCase):
     def setUp(self) -> None:

--- a/tests/flask_integration/test_query_plans_view.py
+++ b/tests/flask_integration/test_query_plans_view.py
@@ -73,3 +73,21 @@ class QueryPlansTests(ViewTestCase):
         )
         assert EXPECTED_PLAN_NAME in response.text
         assert UNEXPECTED_PLAN_NAME not in response.text
+
+    def test_that_plans_can_get_ordered_by_planner_name(self) -> None:
+        self.login_member()
+        COMPANY_NAME_1 = f"A-{uuid4()}"
+        COMPANY_NAME_2 = f"C-{uuid4()}"
+        COMPANY_NAME_3 = f"B-{uuid4()}"
+        planner_1 = self.company_generator.create_company(name=COMPANY_NAME_1)
+        planner_2 = self.company_generator.create_company(name=COMPANY_NAME_2)
+        planner_3 = self.company_generator.create_company(name=COMPANY_NAME_3)
+        self.plan_generator.create_plan(planner=planner_1)
+        self.plan_generator.create_plan(planner=planner_2)
+        self.plan_generator.create_plan(planner=planner_3)
+        response = self.client.get(URL, query_string={"radio": "company_name"})
+        assert (
+            response.text.index(COMPANY_NAME_1)
+            < response.text.index(COMPANY_NAME_3)
+            < response.text.index(COMPANY_NAME_2)
+        )


### PR DESCRIPTION
Before this change it was not possible to order a plan result by planner name AND join it with planner, cooperation and cooperating plans because a  `psycopg2.errors.GroupingError` would be raised.  Grouping has been added in the `ordered_by_planner_name` method to prevent this.

fixes #1093

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (3x)