### PR TITLE
Allow to search for expired plans

### DIFF
--- a/arbeitszeit/use_cases/query_plans.py
+++ b/arbeitszeit/use_cases/query_plans.py
@@ -46,6 +46,7 @@ class QueriedPlan:
     is_public_service: bool
     is_cooperating: bool
     activation_date: datetime
+    is_expired: bool
 
 
 @dataclass
@@ -53,6 +54,7 @@ class QueryPlansRequest:
     query_string: Optional[str]
     filter_category: PlanFilter
     sorting_category: PlanSorting
+    include_expired_plans: bool
     offset: Optional[int] = None
     limit: Optional[int] = None
 
@@ -64,11 +66,9 @@ class QueryPlans:
 
     def __call__(self, request: QueryPlansRequest) -> PlanQueryResponse:
         now = self.datetime_service.now()
-        plans = (
-            self.database_gateway.get_plans()
-            .that_will_expire_after(now)
-            .that_were_activated_before(now)
-        )
+        plans = self.database_gateway.get_plans().that_were_activated_before(now)
+        if not request.include_expired_plans:
+            plans = plans.that_will_expire_after(now)
         total_results = len(plans)
         plans = self._apply_filter(plans, request.query_string, request.filter_category)
         plans = self._apply_sorting(plans, request.sorting_category)
@@ -129,4 +129,5 @@ class QueryPlans:
             is_public_service=plan.is_public_service,
             is_cooperating=bool(cooperation),
             activation_date=plan.activation_date,
+            is_expired=plan.is_expired_as_of(self.datetime_service.now()),
         )

--- a/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
+++ b/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
@@ -41,6 +41,7 @@ class QueryPlansSortedByActivationDateBenchmark:
             query_string=None,
             filter_category=query_plans.PlanFilter.by_product_name,
             sorting_category=query_plans.PlanSorting.by_activation,
+            include_expired_plans=False,
             limit=None,
             offset=None,
         )

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -89,6 +89,10 @@ class PlanSearchForm(Form):
         default="activation",
     )
 
+    include_expired_plans = BooleanField(
+        trans.lazy_gettext("Search also for expired plans"),
+    )
+
     def get_query_string(self) -> str:
         return self.data["search"]
 
@@ -97,6 +101,9 @@ class PlanSearchForm(Form):
 
     def get_radio_string(self) -> str:
         return self.data["radio"]
+
+    def get_checkbox_value(self) -> bool:
+        return self.data["include_expired_plans"]
 
 
 class RegisterForm(Form):

--- a/arbeitszeit_flask/templates/user/query_plans.html
+++ b/arbeitszeit_flask/templates/user/query_plans.html
@@ -10,7 +10,7 @@
     <div class="columns is-centered">
         <div class="column is-one-third">
             <h1 class="title">
-                {{ gettext("Active plans") }}
+                {{ gettext("Plans") }}
             </h1>
             <form method="get">
                 <div class="field">
@@ -26,13 +26,16 @@
                         {{ form.search(class_="input is-large") }}
                     </div>
                 </div>
-                <p class="has-text-weight-semibold">Sort by:</p>
                 <div class="field">
+                    <label class="label">{{ gettext("Sort by") }}</label>
                     <div class="control">
                         {% for subfield in form.radio %}
                         <span>{{ subfield }} {{ subfield.label }}</span>
                         {% endfor %}
                     </div>
+                </div>
+                <div class="field">
+                    {{ form.include_expired_plans }} {{ form.include_expired_plans.label }}
                 </div>
                 <input type="hidden" name="page" value="1">
                 <button class="button is-block is-primary is-large is-fullwidth">
@@ -73,6 +76,9 @@
                         {% endif %}
                         {% if column.is_public_service %}
                         <span class="tag is-warning">{{ gettext("Public") }}</span>
+                        {% endif %}
+                        {% if column.is_expired %}
+                        <span class="tag is-danger">{{ gettext("Expired") }}</span>
                         {% endif %}
                     </div>
                 </div>

--- a/arbeitszeit_web/api/controllers/query_plans_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_plans_api_controller.py
@@ -36,6 +36,7 @@ class QueryPlansApiController:
             query_string=None,
             filter_category=PlanFilter.by_plan_id,
             sorting_category=PlanSorting.by_activation,
+            include_expired_plans=False,
             offset=offset,
             limit=limit,
         )

--- a/arbeitszeit_web/query_plans.py
+++ b/arbeitszeit_web/query_plans.py
@@ -27,6 +27,8 @@ class QueryPlansFormData(Protocol):
 
     def get_radio_string(self) -> str: ...
 
+    def get_checkbox_value(self) -> bool: ...
+
 
 _PAGE_SIZE = 15
 
@@ -42,15 +44,18 @@ class QueryPlansController:
             query = None
             filter_category = PlanFilter.by_product_name
             sorting_category = PlanSorting.by_activation
+            include_expired_plans = False
         else:
             query = form.get_query_string().strip() or None
             filter_category = self._import_filter_category(form)
             sorting_category = self._import_sorting_category(form)
+            include_expired_plans = self._import_include_expired(form)
         offset = self._get_pagination_offset(request) if request else 0
         return QueryPlansRequest(
             query_string=query,
             filter_category=filter_category,
             sorting_category=sorting_category,
+            include_expired_plans=include_expired_plans,
             offset=offset,
             limit=_PAGE_SIZE,
         )
@@ -80,6 +85,9 @@ class QueryPlansController:
             sorting_category = PlanSorting.by_activation
         return sorting_category
 
+    def _import_include_expired(self, form: QueryPlansFormData) -> bool:
+        return form.get_checkbox_value()
+
 
 @dataclass
 class ResultTableRow:
@@ -91,6 +99,7 @@ class ResultTableRow:
     price_per_unit: str
     is_public_service: bool
     is_cooperating: bool
+    is_expired: bool
 
 
 @dataclass
@@ -143,6 +152,7 @@ class QueryPlansPresenter:
                         price_per_unit=str(round(result.price_per_unit, 2)),
                         is_public_service=result.is_public_service,
                         is_cooperating=result.is_cooperating,
+                        is_expired=result.is_expired,
                     )
                     for result in response.results
                 ],

--- a/tests/use_cases/test_approve_plan.py
+++ b/tests/use_cases/test_approve_plan.py
@@ -237,6 +237,7 @@ class UseCaseTests(BaseTestCase):
                 query_string=None,
                 filter_category=PlanFilter.by_plan_id,
                 sorting_category=PlanSorting.by_activation,
+                include_expired_plans=False,
             )
         )
         assert response.results

--- a/tests/use_cases/test_query_plans.py
+++ b/tests/use_cases/test_query_plans.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Optional
+from enum import Enum, auto
 from uuid import UUID
+
+from parameterized import parameterized
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.query_plans import (
@@ -14,28 +16,149 @@ from arbeitszeit.use_cases.query_plans import (
 from tests.use_cases.base_test_case import BaseTestCase
 
 
+class SearchStrategy(Enum):
+    by_id_sort_by_date_exclude_expired = auto()
+    by_id_sort_by_date_include_expired = auto()
+    by_id_sort_by_name_exclude_expired = auto()
+    by_id_sort_by_name_include_expired = auto()
+    by_name_sort_by_date_exclude_expired = auto()
+    by_name_sort_by_date_include_expired = auto()
+    by_name_sort_by_name_exclude_expired = auto()
+    by_name_sort_by_name_include_expired = auto()
+
+
 class UseCaseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.query_plans = self.injector.get(QueryPlans)
 
-    def test_that_no_plan_is_returned_when_searching_an_empty_repository(self) -> None:
-        response = self.query_plans(self.make_request(None, PlanFilter.by_product_name))
-        assert not response.results
-        response = self.query_plans(self.make_request(None, PlanFilter.by_plan_id))
+    @parameterized.expand([(strategy,) for strategy in SearchStrategy])
+    def test_that_no_plan_is_returned_when_searching_an_empty_repository(
+        self,
+        search_strategy: SearchStrategy,
+    ) -> None:
+        response = self.query_plans(self.make_request(search_strategy))
         assert not response.results
 
-    def test_that_plans_where_id_is_exact_match_are_returned(self) -> None:
+    @parameterized.expand([(strategy,) for strategy in SearchStrategy])
+    def test_that_a_plan_awaiting_approval_is_not_returned(
+        self,
+        strategy: SearchStrategy,
+    ) -> None:
+        self.plan_generator.create_plan(approved=False)
+        response = self.query_plans(self.make_request(strategy))
+        assert not response.results
+
+    @parameterized.expand([(strategy,) for strategy in SearchStrategy])
+    def test_that_all_active_plans_are_returned(
+        self,
+        search_strategy: SearchStrategy,
+    ) -> None:
+        expected_number_of_plans = 3
+        for _ in range(expected_number_of_plans):
+            self.plan_generator.create_plan()
+        response = self.query_plans(self.make_request(search_strategy))
+        assert len(response.results) == expected_number_of_plans
+
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_id_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_name_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_id_sort_by_name_exclude_expired,),
+            (SearchStrategy.by_name_sort_by_name_exclude_expired,),
+        ]
+    )
+    def test_that_no_expired_plans_are_returned_when_they_are_excluded(
+        self,
+        search_strategy: SearchStrategy,
+    ) -> None:
+        expected_number_of_plans = 0
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        for _ in range(3):
+            self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
+        response = self.query_plans(self.make_request(search_strategy))
+        assert len(response.results) == expected_number_of_plans
+
+    def test_that_only_active_plan_is_returned_when_expired_plans_are_excluded(
+        self,
+    ) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
         expected_plan = self.plan_generator.create_plan()
-        query = str(expected_plan)
-        response = self.query_plans(self.make_request(query, PlanFilter.by_plan_id))
+        response = self.query_plans(
+            self.make_request(SearchStrategy.by_id_sort_by_date_exclude_expired)
+        )
+        assert len(response.results) == 1
         assert self.assertPlanInResults(expected_plan, response)
 
-    def test_query_with_substring_of_id_returns_correct_result(self) -> None:
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_id_sort_by_date_include_expired,),
+            (SearchStrategy.by_name_sort_by_date_include_expired,),
+            (SearchStrategy.by_id_sort_by_name_include_expired,),
+            (SearchStrategy.by_name_sort_by_name_include_expired,),
+        ]
+    )
+    def test_that_expired_plans_are_returned_when_they_are_included(
+        self,
+        search_strategy: SearchStrategy,
+    ) -> None:
+        expected_number_of_plans = 3
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        for _ in range(expected_number_of_plans):
+            self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
+        response = self.query_plans(self.make_request(search_strategy))
+        assert len(response.results) == expected_number_of_plans
+
+    def test_that_expired_plan_is_shown_as_expired(
+        self,
+    ) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
+        response = self.query_plans(
+            self.make_request(SearchStrategy.by_id_sort_by_date_include_expired)
+        )
+        assert response.results[0].is_expired
+
+    def test_that_active_plan_is_not_shown_as_expired(
+        self,
+    ) -> None:
+        self.plan_generator.create_plan()
+        response = self.query_plans(self.make_request())
+        assert not response.results[0].is_expired
+
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_id_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_id_sort_by_date_include_expired,),
+            (SearchStrategy.by_id_sort_by_name_exclude_expired,),
+            (SearchStrategy.by_id_sort_by_name_include_expired,),
+        ]
+    )
+    def test_that_active_plan_where_id_is_exact_match_is_returned(
+        self,
+        search_strategy: SearchStrategy,
+    ) -> None:
+        self.plan_generator.create_plan()
+        expected_plan = self.plan_generator.create_plan()
+        response = self.query_plans(
+            self.make_request(search_strategy=search_strategy, query=str(expected_plan))
+        )
+        assert len(response.results) == 1
+        assert self.assertPlanInResults(expected_plan, response)
+
+    def test_query_with_substring_of_id_returns_correct_plan(self) -> None:
         expected_plan = self.plan_generator.create_plan()
         substring_query = str(expected_plan)[5:10]
         response = self.query_plans(
-            self.make_request(substring_query, PlanFilter.by_plan_id)
+            self.make_request(
+                search_strategy=SearchStrategy.by_id_sort_by_date_exclude_expired,
+                query=substring_query,
+            )
         )
         assert self.assertPlanInResults(expected_plan, response)
 
@@ -43,7 +166,10 @@ class UseCaseTests(BaseTestCase):
         expected_plan = self.plan_generator.create_plan(product_name="Name XYZ")
         query = "Name XYZ"
         response = self.query_plans(
-            self.make_request(query, PlanFilter.by_product_name)
+            self.make_request(
+                search_strategy=SearchStrategy.by_name_sort_by_date_exclude_expired,
+                query=query,
+            )
         )
         assert self.assertPlanInResults(expected_plan, response)
 
@@ -51,7 +177,10 @@ class UseCaseTests(BaseTestCase):
         expected_plan = self.plan_generator.create_plan(product_name="Name XYZ")
         query = "me X"
         response = self.query_plans(
-            self.make_request(query, PlanFilter.by_product_name)
+            self.make_request(
+                search_strategy=SearchStrategy.by_name_sort_by_date_exclude_expired,
+                query=query,
+            )
         )
         assert self.assertPlanInResults(expected_plan, response)
 
@@ -59,12 +188,24 @@ class UseCaseTests(BaseTestCase):
         expected_plan = self.plan_generator.create_plan(product_name="Name XYZ")
         query = "xyz"
         response = self.query_plans(
-            self.make_request(query, PlanFilter.by_product_name)
+            self.make_request(
+                search_strategy=SearchStrategy.by_name_sort_by_date_exclude_expired,
+                query=query,
+            )
         )
         assert self.assertPlanInResults(expected_plan, response)
 
-    def test_that_plans_are_returned_in_order_of_activation_when_requested_with_newest_plan_first(
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_id_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_id_sort_by_date_include_expired,),
+            (SearchStrategy.by_name_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_name_sort_by_date_include_expired,),
+        ]
+    )
+    def test_that_plans_are_returned_in_order_of_activation_with_newest_plan_first_when_requested(
         self,
+        search_strategy: SearchStrategy,
     ) -> None:
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
         expected_third = self.plan_generator.create_plan()
@@ -73,29 +214,41 @@ class UseCaseTests(BaseTestCase):
         self.datetime_service.advance_time(timedelta(days=1))
         expected_first = self.plan_generator.create_plan()
         self.datetime_service.advance_time(timedelta(days=1))
-        response = self.query_plans(
-            self.make_request(sorting=PlanSorting.by_activation)
-        )
+        response = self.query_plans(self.make_request(search_strategy=search_strategy))
         assert response.results[0].plan_id == expected_first
         assert response.results[1].plan_id == expected_second
         assert response.results[2].plan_id == expected_third
 
-    def test_that_plans_are_returned_in_order_of_company_name_when_requested(
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_id_sort_by_name_exclude_expired,),
+            (SearchStrategy.by_id_sort_by_name_include_expired,),
+            (SearchStrategy.by_name_sort_by_name_exclude_expired,),
+            (SearchStrategy.by_name_sort_by_name_include_expired,),
+        ]
+    )
+    def test_that_plans_are_returned_sorted_by_company_name_when_requested(
         self,
+        search_strategy: SearchStrategy,
     ) -> None:
         for name in ["c_name", "a_name", "B_name"]:
             self.plan_generator.create_plan(
                 planner=self.company_generator.create_company(name=name),
             )
-        response = self.query_plans(
-            self.make_request(sorting=PlanSorting.by_company_name)
-        )
+        response = self.query_plans(self.make_request(search_strategy=search_strategy))
         assert response.results[0].company_name == "a_name"
         assert response.results[1].company_name == "B_name"
         assert response.results[2].company_name == "c_name"
 
-    def test_that_filtered_plans_by_name_are_returned_in_order_of_activation(
+    @parameterized.expand(
+        [
+            (SearchStrategy.by_name_sort_by_date_exclude_expired,),
+            (SearchStrategy.by_name_sort_by_date_include_expired,),
+        ]
+    )
+    def test_that_plans_filtered_by_name_are_returned_sorted_by_date_if_requested(
         self,
+        search_strategy: SearchStrategy,
     ) -> None:
         self.datetime_service.freeze_time(datetime(2000, 1, 4))
         expected_second = self.plan_generator.create_plan(product_name="abcde")
@@ -108,8 +261,7 @@ class UseCaseTests(BaseTestCase):
         )
         response = self.query_plans(
             self.make_request(
-                sorting=PlanSorting.by_activation,
-                category=PlanFilter.by_product_name,
+                search_strategy=search_strategy,
                 query="abc",
             )
         )
@@ -141,13 +293,26 @@ class UseCaseTests(BaseTestCase):
             == self.price_checker.get_labour_per_unit(plan)
         )
 
-    def test_that_price_of_cooperating_plans_is_correctly_displayed(self) -> None:
+    def test_that_two_cooperating_plans_have_the_same_price(self) -> None:
         cooperation = self.cooperation_generator.create_cooperation()
-        plan1 = self.plan_generator.create_plan(cooperation=cooperation, amount=1000)
-        plan2 = self.plan_generator.create_plan(cooperation=cooperation, amount=1)
-        response = self.query_plans(
-            self.make_request(sorting=PlanSorting.by_activation)
+        self.plan_generator.create_plan(cooperation=cooperation, amount=1000)
+        self.plan_generator.create_plan(cooperation=cooperation, amount=1)
+        response = self.query_plans(self.make_request())
+        assert response.results[0].price_per_unit == response.results[1].price_per_unit
+
+    def test_that_price_of_cooperating_plans_is_correct(
+        self,
+    ) -> None:
+        cooperation = self.cooperation_generator.create_cooperation()
+        plan1 = self.plan_generator.create_plan(
+            cooperation=cooperation,
+            amount=1000,
         )
+        plan2 = self.plan_generator.create_plan(
+            cooperation=cooperation,
+            amount=1,
+        )
+        response = self.query_plans(self.make_request())
         assert response.results[0].price_per_unit == self.price_checker.get_unit_price(
             plan1
         )
@@ -194,26 +359,55 @@ class UseCaseTests(BaseTestCase):
         response = self.query_plans(self.make_request(offset=15))
         assert len(response.results) == 5
 
-    def test_that_a_plan_awaiting_approval_is_not_returned(self) -> None:
-        planner = self.company_generator.create_company()
-        self.plan_generator.create_plan(approved=False, planner=planner)
-        response = self.query_plans(self.make_request())
-        assert not response.results
-
     def make_request(
         self,
-        query: Optional[str] = None,
-        category: Optional[PlanFilter] = None,
-        sorting: Optional[PlanSorting] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
+        search_strategy: SearchStrategy | None = None,
+        query: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
     ) -> QueryPlansRequest:
+        if search_strategy is None:
+            search_strategy = SearchStrategy.by_name_sort_by_date_exclude_expired
+        match search_strategy:
+            case SearchStrategy.by_id_sort_by_date_exclude_expired:
+                category = PlanFilter.by_plan_id
+                sorting = PlanSorting.by_activation
+                include_expired_plans = False
+            case SearchStrategy.by_id_sort_by_date_include_expired:
+                category = PlanFilter.by_plan_id
+                sorting = PlanSorting.by_activation
+                include_expired_plans = True
+            case SearchStrategy.by_id_sort_by_name_exclude_expired:
+                category = PlanFilter.by_plan_id
+                sorting = PlanSorting.by_company_name
+                include_expired_plans = False
+            case SearchStrategy.by_id_sort_by_name_include_expired:
+                category = PlanFilter.by_plan_id
+                sorting = PlanSorting.by_company_name
+                include_expired_plans = True
+            case SearchStrategy.by_name_sort_by_date_exclude_expired:
+                category = PlanFilter.by_product_name
+                sorting = PlanSorting.by_activation
+                include_expired_plans = False
+            case SearchStrategy.by_name_sort_by_date_include_expired:
+                category = PlanFilter.by_product_name
+                sorting = PlanSorting.by_activation
+                include_expired_plans = True
+            case SearchStrategy.by_name_sort_by_name_exclude_expired:
+                category = PlanFilter.by_product_name
+                sorting = PlanSorting.by_company_name
+                include_expired_plans = False
+            case SearchStrategy.by_name_sort_by_name_include_expired:
+                category = PlanFilter.by_product_name
+                sorting = PlanSorting.by_company_name
+                include_expired_plans = True
         return QueryPlansRequest(
-            query_string=query or "",
-            filter_category=category or PlanFilter.by_product_name,
-            sorting_category=sorting or PlanSorting.by_activation,
+            query_string=query,
+            filter_category=category,
+            sorting_category=sorting,
             offset=offset,
             limit=limit,
+            include_expired_plans=include_expired_plans,
         )
 
     def assertPlanInResults(self, plan: UUID, response: PlanQueryResponse) -> bool:

--- a/tests/www/controllers/test_query_plans_controller.py
+++ b/tests/www/controllers/test_query_plans_controller.py
@@ -82,6 +82,12 @@ class QueryPlansControllerTests(BaseTestCase):
         )
         self.assertEqual(request.sorting_category, PlanSorting.by_company_name)
 
+    def test_that_empty_include_expired_plans_field_results_in_false(
+        self,
+    ) -> None:
+        request = self.controller.import_form_data()
+        self.assertFalse(request.include_expired_plans)
+
 
 class PaginationTests(BaseTestCase):
     def setUp(self) -> None:
@@ -127,11 +133,13 @@ def make_fake_form(
     query: Optional[str] = None,
     filter_category: Optional[str] = None,
     sorting_category: Optional[str] = None,
+    include_expired_plans: Optional[bool] = None,
 ) -> FakeQueryPlansForm:
     return FakeQueryPlansForm(
         query=query or "",
         products_filter=filter_category or "Produktname",
         sorting_category=sorting_category or "activation",
+        include_expired_plans=include_expired_plans or False,
     )
 
 
@@ -140,6 +148,7 @@ class FakeQueryPlansForm:
     query: str
     products_filter: str
     sorting_category: str
+    include_expired_plans: bool
 
     def get_query_string(self) -> str:
         return self.query
@@ -149,3 +158,6 @@ class FakeQueryPlansForm:
 
     def get_radio_string(self) -> str:
         return self.sorting_category
+
+    def get_checkbox_value(self) -> bool:
+        return self.include_expired_plans

--- a/tests/www/presenters/data_generators.py
+++ b/tests/www/presenters/data_generators.py
@@ -24,26 +24,19 @@ class QueriedPlanGenerator:
         self,
         plan_id: Optional[UUID] = None,
         company_id: Optional[UUID] = None,
-        is_cooperating: Optional[bool] = None,
-        description: Optional[str] = None,
+        is_cooperating: bool = False,
+        description: str = "For eating\nNext paragraph\rThird one",
         activation_date: Optional[datetime] = None,
-        price_per_unit: Optional[Decimal] = None,
-        labour_cost_per_unit: Optional[Decimal] = None,
+        price_per_unit: Decimal = Decimal(5),
+        labour_cost_per_unit: Decimal = Decimal(1),
+        is_expired: bool = False,
     ) -> QueriedPlan:
         if plan_id is None:
             plan_id = uuid4()
         if company_id is None:
             company_id = uuid4()
-        if is_cooperating is None:
-            is_cooperating = False
-        if description is None:
-            description = "For eating\nNext paragraph\rThird one"
         if activation_date is None:
             activation_date = datetime.now()
-        if price_per_unit is None:
-            price_per_unit = Decimal(5)
-        if labour_cost_per_unit is None:
-            labour_cost_per_unit = Decimal(1)
         return QueriedPlan(
             plan_id=plan_id,
             company_name="Planner name",
@@ -55,6 +48,7 @@ class QueriedPlanGenerator:
             is_public_service=False,
             is_cooperating=is_cooperating,
             activation_date=activation_date,
+            is_expired=is_expired,
         )
 
     def get_response(
@@ -80,6 +74,7 @@ class QueriedPlanGenerator:
                 query_string=query_string,
                 filter_category=requested_filter_category,
                 sorting_category=requested_sorting_category,
+                include_expired_plans=False,
             ),
         )
 

--- a/tests/www/presenters/test_query_plans_presenter.py
+++ b/tests/www/presenters/test_query_plans_presenter.py
@@ -1,6 +1,8 @@
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
+from parameterized import parameterized
+
 from arbeitszeit_web.query_plans import QueryPlansPresenter
 from arbeitszeit_web.session import UserRole
 from tests.request import FakeRequest
@@ -109,6 +111,20 @@ class QueryPlansPresenterTests(BaseTestCase):
         self.assertEqual(
             table_row.is_public_service,
             False,
+        )
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_is_expired_bool_is_passed_on_to_view_model(
+        self, is_expired: bool
+    ) -> None:
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(is_expired=is_expired)]
+        )
+        presentation = self.presenter.present(response, self.request)
+        table_row = presentation.results.rows[0]
+        self.assertEqual(
+            table_row.is_expired,
+            is_expired,
         )
 
     def test_that_description_is_shown_without_line_returns(self) -> None:


### PR DESCRIPTION
This commit changes the `QueryPlans` Use Case to search also for expired plans, if specified in the request.

The use case test has been refactored for easier testing of different search strategies.

Html, controller and presenter have been adapted as well.

Fixes #1096

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b (8x)