### PR TITLE
Fix bug of incorrect `total_results` of queried plans

### DIFF
--- a/arbeitszeit/use_cases/query_plans.py
+++ b/arbeitszeit/use_cases/query_plans.py
@@ -69,8 +69,8 @@ class QueryPlans:
             .that_will_expire_after(now)
             .that_were_activated_before(now)
         )
-        total_results = len(plans)
         plans = self._apply_filter(plans, request.query_string, request.filter_category)
+        total_results = len(plans)
         plans = self._apply_sorting(plans, request.sorting_category)
         planning_info = plans.joined_with_planner_and_cooperation_and_cooperating_plans(
             now


### PR DESCRIPTION
Calculation of total number of queried plans (`total_results`) has to be calculated AFTER the filtering took place.

See also this comment: https://github.com/ida-arbeitszeit/arbeitszeitapp/pull/1101#discussion_r1826591814

Plan: 8ec03a5b-3dbe-465d-a533-4b3bfe16121b