### PR TITLE
add git to dev shell environment

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -6,6 +6,7 @@
   glibcLocales,
   includeGlibcLocales,
   lib,
+  git,
 }:
 mkShell (
   {
@@ -27,6 +28,7 @@ mkShell (
       ++ [
         nixfmt
         sqlite
+        git
       ]
       ++ python3.pkgs.arbeitszeitapp.optional-dependencies.profiling;
     inputsFrom = [ python3.pkgs.arbeitszeitapp ];


### PR DESCRIPTION
I am adding this since for some reason, after latest dependencies update, my setup with hub installed via homebrew and direnv does not work anymore. Executing 'git status' returned error: tool 'git' not found. 
