### PR TITLE
Create `RemoveWorkerFromCompanyPresenter`

### DIFF
--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -240,3 +240,6 @@ class GeneralUrlIndex:
 
     def get_member_login_url(self) -> str:
         return url_for("auth.login_member")
+
+    def get_invite_worker_to_company_url(self) -> str:
+        return url_for("main_company.invite_worker_to_company")

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -140,6 +140,8 @@ class UrlIndex(Protocol):
 
     def get_member_login_url(self) -> str: ...
 
+    def get_invite_worker_to_company_url(self) -> str: ...
+
 
 @dataclass
 class UserUrlIndex:

--- a/arbeitszeit_web/www/presenters/remove_worker_from_company_presenter.py
+++ b/arbeitszeit_web/www/presenters/remove_worker_from_company_presenter.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.remove_worker_from_company import Response as UseCaseResponse
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+from arbeitszeit_web.www.response import Redirect
+
+
+@dataclass
+class ErrorCode:
+    code: int
+
+
+ViewModel = Redirect | ErrorCode
+
+
+@dataclass
+class RemoveWorkerFromCompanyPresenter:
+    notifier: Notifier
+    translator: Translator
+    url_index: UrlIndex
+
+    def present(self, use_case_response: UseCaseResponse) -> ViewModel:
+        if not use_case_response.is_rejected:
+            self.notifier.display_info(
+                self.translator.gettext("Worker successfully removed from company.")
+            )
+            return Redirect(url=self.url_index.get_invite_worker_to_company_url())
+
+        assert use_case_response.rejection_reason is not None
+
+        match use_case_response.rejection_reason:
+            case UseCaseResponse.RejectionReason.company_not_found:
+                message = "Company not found."
+                code = 404
+            case UseCaseResponse.RejectionReason.not_workplace_of_worker:
+                message = "Worker is not a member of the company."
+                code = 400
+            case UseCaseResponse.RejectionReason.worker_not_found:
+                message = "Worker not found."
+                code = 404
+            case _:
+                message = "An unknown error occurred."
+                code = 500
+        self.notifier.display_warning(self.translator.gettext(message))
+        return ErrorCode(code)

--- a/tests/www/presenters/test_remove_worker_from_company_presenter.py
+++ b/tests/www/presenters/test_remove_worker_from_company_presenter.py
@@ -1,0 +1,82 @@
+from parameterized import parameterized
+
+from arbeitszeit.use_cases.remove_worker_from_company import Response as UseCaseResponse
+from arbeitszeit_web.www.presenters import remove_worker_from_company_presenter
+from arbeitszeit_web.www.presenters.remove_worker_from_company_presenter import (
+    RemoveWorkerFromCompanyPresenter as Presenter,
+)
+from arbeitszeit_web.www.response import Redirect
+from tests.www.base_test_case import BaseTestCase
+
+
+class TestRemoveWorkerFromCompanyPresenter(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(Presenter)
+
+    def test_correct_redirect_is_returned_on_success(self) -> None:
+        response = self.create_response(rejection_reason=None)
+        view_model = self.presenter.present(response)
+        assert isinstance(view_model, Redirect)
+        assert view_model.url == self.url_index.get_invite_worker_to_company_url()
+
+    @parameterized.expand(
+        [
+            (UseCaseResponse.RejectionReason.company_not_found, 404),
+            (UseCaseResponse.RejectionReason.not_workplace_of_worker, 400),
+            (UseCaseResponse.RejectionReason.worker_not_found, 404),
+        ]
+    )
+    def test_correct_status_code_is_returned_on_rejection(
+        self, rejection_reason: UseCaseResponse.RejectionReason, expected_code: int
+    ) -> None:
+        response = self.create_response(rejection_reason)
+        view_model = self.presenter.present(response)
+        assert isinstance(view_model, remove_worker_from_company_presenter.ErrorCode)
+        assert view_model.code == expected_code
+
+    def test_no_warning_is_displayed_on_success(self) -> None:
+        response = self.create_response(rejection_reason=None)
+        self.presenter.present(response)
+        assert not self.notifier.warnings
+
+    def test_correct_info_is_displayed_on_success(self) -> None:
+        response = self.create_response(rejection_reason=None)
+        self.presenter.present(response)
+        assert len(self.notifier.infos) == 1
+        assert self.notifier.infos[0] == self.translator.gettext(
+            "Worker successfully removed from company."
+        )
+
+    @parameterized.expand(
+        [(rejection_reason,) for rejection_reason in UseCaseResponse.RejectionReason]
+    )
+    def test_no_info_is_displayed_on_rejection(
+        self, rejection_reason: UseCaseResponse.RejectionReason
+    ) -> None:
+        response = self.create_response(rejection_reason)
+        self.presenter.present(response)
+        assert not self.notifier.infos
+
+    @parameterized.expand(
+        [
+            (UseCaseResponse.RejectionReason.company_not_found, "Company not found."),
+            (
+                UseCaseResponse.RejectionReason.not_workplace_of_worker,
+                "Worker is not a member of the company.",
+            ),
+            (UseCaseResponse.RejectionReason.worker_not_found, "Worker not found."),
+        ]
+    )
+    def test_correct_warning_is_displayed_on_rejection(
+        self, rejection_reason: UseCaseResponse.RejectionReason, message: str
+    ) -> None:
+        response = self.create_response(rejection_reason)
+        self.presenter.present(response)
+        assert len(self.notifier.warnings) == 1
+        assert self.notifier.warnings[0] == self.translator.gettext(message)
+
+    def create_response(
+        self, rejection_reason: UseCaseResponse.RejectionReason | None
+    ) -> UseCaseResponse:
+        return UseCaseResponse(rejection_reason)

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -61,6 +61,7 @@ class UrlIndexTestImpl:
     get_global_barplot_for_means_of_production_url = UrlIndexMethod()
     get_global_barplot_for_plans_url = UrlIndexMethod()
     get_hide_plan_url = UrlIndexMethod()
+    get_invite_worker_to_company_url = UrlIndexMethod()
     get_language_change_url = UrlIndexMethod()
     get_line_plot_of_company_a_account = UrlIndexMethod()
     get_line_plot_of_company_p_account = UrlIndexMethod()


### PR DESCRIPTION
On success, the presenter returns a redirect url to the "invite worker" route (where the company's workers are listed). Else, it returns an appropriate error code.

see #1092