### PR TITLE
Small improvements to our test framework

### DIFF
--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -7,7 +7,6 @@ from flask import Flask, current_app
 from flask_sqlalchemy import SQLAlchemy
 
 from arbeitszeit.injector import Module
-from arbeitszeit.records import Company
 from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
 from arbeitszeit_flask.token import FlaskTokenService
 from tests.data_generators import (
@@ -181,7 +180,7 @@ class ViewTestCase(FlaskTestCase):
         password: Optional[str] = None,
         email: Optional[str] = None,
         confirm_company: bool = True,
-    ) -> Company:
+    ) -> UUID:
         if password is None:
             password = "password123"
         if email is None:
@@ -208,7 +207,7 @@ class ViewTestCase(FlaskTestCase):
             self.database_gateway.get_companies().with_email_address(email).first()
         )
         assert company
-        return company
+        return company.id
 
     def _confirm_company(
         self,
@@ -248,8 +247,8 @@ class ViewTestCase(FlaskTestCase):
         elif login == LogInUser.unconfirmed_member:
             return self.login_member(confirm_member=False)
         elif login == LogInUser.company:
-            return self.login_company().id
+            return self.login_company()
         elif login == LogInUser.unconfirmed_company:
-            return self.login_company(confirm_company=False).id
+            return self.login_company(confirm_company=False)
         elif login == LogInUser.accountant:
             return self.login_accountant()

--- a/tests/flask_integration/test_company_consumptions_view.py
+++ b/tests/flask_integration/test_company_consumptions_view.py
@@ -32,7 +32,7 @@ class AuthTests(ViewTestCase):
 class UnconfirmedCompanyTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company(confirm_company=False)
+        self.login_company(confirm_company=False)
         self.url = "/company/consumptions"
 
     def test_unconfirmed_company_gets_302(self) -> None:

--- a/tests/flask_integration/test_company_dashboard_view.py
+++ b/tests/flask_integration/test_company_dashboard_view.py
@@ -57,7 +57,7 @@ class MemberTest(ViewTestCase):
 class UnconfirmedCompanyTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company(confirm_company=False)
+        self.login_company(confirm_company=False)
         self.url = "/company/dashboard"
 
     def test_unconfirmed_company_gets_302(self) -> None:

--- a/tests/flask_integration/test_create_draft_from_plan_view.py
+++ b/tests/flask_integration/test_create_draft_from_plan_view.py
@@ -9,12 +9,12 @@ class ViewTests(ViewTestCase):
         self.company = self.login_company()
 
     def test_can_create_render_creation_page_from_existing_plan(self) -> None:
-        plan = self.plan_generator.create_plan(planner=self.company.id)
+        plan = self.plan_generator.create_plan(planner=self.company)
         response = self.client.post(self._get_url(plan))
         self.assertEqual(response.status_code, 302)
 
     def test_get_405_method_not_allowed_when_trying_to_get_the_route(self) -> None:
-        plan = self.plan_generator.create_plan(planner=self.company.id)
+        plan = self.plan_generator.create_plan(planner=self.company)
         response = self.client.get(self._get_url(plan))
         self.assertEqual(response.status_code, 405)
 

--- a/tests/flask_integration/test_create_draft_view.py
+++ b/tests/flask_integration/test_create_draft_view.py
@@ -11,7 +11,7 @@ from .flask import ViewTestCase
 class AuthenticatedCompanyTestsForGet(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company()
+        self.login_company()
 
     def test_get_200_without_url_parameter(
         self,
@@ -77,6 +77,6 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
         )
 
     def _count_drafts_of_company(self) -> int:
-        request = ShowMyPlansRequest(company_id=self.company.id)
+        request = ShowMyPlansRequest(company_id=self.company)
         response = self.show_my_plans.show_company_plans(request)
         return len(response.drafts)

--- a/tests/flask_integration/test_delete_draft_view.py
+++ b/tests/flask_integration/test_delete_draft_view.py
@@ -6,7 +6,7 @@ from .flask import ViewTestCase
 class DeleteDraftViewTests(ViewTestCase):
     def test_get_405_when_getting_url_as_company(self) -> None:
         company = self.login_company()
-        draft = self.plan_generator.draft_plan(planner=company.id)
+        draft = self.plan_generator.draft_plan(planner=company)
         response = self.client.get(self.get_url(draft))
         self.assertEqual(response.status_code, 405)
 
@@ -17,13 +17,13 @@ class DeleteDraftViewTests(ViewTestCase):
 
     def test_get_302_when_posting_url_as_company_for_existing_draft(self) -> None:
         company = self.login_company()
-        draft = self.plan_generator.draft_plan(planner=company.id)
+        draft = self.plan_generator.draft_plan(planner=company)
         response = self.client.post(self.get_url(draft))
         self.assertEqual(response.status_code, 302)
 
     def test_get_404_when_posting_draft_twice_as_company(self) -> None:
         company = self.login_company()
-        draft = self.plan_generator.draft_plan(planner=company.id)
+        draft = self.plan_generator.draft_plan(planner=company)
         self.client.post(self.get_url(draft))
         response = self.client.post(self.get_url(draft))
         self.assertEqual(response.status_code, 404)

--- a/tests/flask_integration/test_end_cooperation_view.py
+++ b/tests/flask_integration/test_end_cooperation_view.py
@@ -45,7 +45,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
     def test_302_is_returned_when_coop_and_plan_do_exist_and_requester_is_planner(
         self,
     ) -> None:
-        plan = self.plan_generator.create_plan(planner=self.company.id)
+        plan = self.plan_generator.create_plan(planner=self.company)
         cooperation = self.cooperation_generator.create_cooperation(plans=[plan])
         data = {"plan_id": str(plan), "cooperation_id": str(cooperation)}
         response = self.client.post(URL, data=data)

--- a/tests/flask_integration/test_get_draft_details_view.py
+++ b/tests/flask_integration/test_get_draft_details_view.py
@@ -9,7 +9,7 @@ class ViewTests(ViewTestCase):
         self.company = self.login_company()
 
     def test_get_proper_response_code_with_correct_draft_id(self) -> None:
-        draft = self.plan_generator.draft_plan(planner=self.company.id)
+        draft = self.plan_generator.draft_plan(planner=self.company)
         response = self.client.get(self.get_url(draft))
         self.assertEqual(response.status_code, 200)
 
@@ -29,7 +29,7 @@ class ViewTests(ViewTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_posting_valid_data_for_existing_plan_results_in_302(self) -> None:
-        draft = self.plan_generator.draft_plan(planner=self.company.id)
+        draft = self.plan_generator.draft_plan(planner=self.company)
         response = self.client.post(self.get_url(draft), data=self._valid_form_data())
         self.assertEqual(response.status_code, 302)
 

--- a/tests/flask_integration/test_get_plan_details.py
+++ b/tests/flask_integration/test_get_plan_details.py
@@ -23,7 +23,7 @@ class AuthenticatedMemberTests(ViewTestCase):
 class AuthenticatedCompanyTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company()
+        self.login_company()
 
     def test_get_404_when_plan_does_not_exist(self) -> None:
         url = f"/company/plan_details/{uuid4()}"

--- a/tests/flask_integration/test_hide_plan_view.py
+++ b/tests/flask_integration/test_hide_plan_view.py
@@ -6,7 +6,7 @@ from .flask import ViewTestCase
 class HidePlanViewTests(ViewTestCase):
     def test_that_trying_hide_existing_plan_returns_302(self) -> None:
         company = self.login_company()
-        plan = self.plan_generator.create_plan(planner=company.id)
+        plan = self.plan_generator.create_plan(planner=company)
         response = self.client.post(f"/company/hide_plan/{plan}")
         assert response.status_code == 302
 

--- a/tests/flask_integration/test_invite_worker_to_company_view.py
+++ b/tests/flask_integration/test_invite_worker_to_company_view.py
@@ -36,7 +36,7 @@ class InviteWorkerToCompanyTests(ViewTestCase):
         company = self.login_company()
         company_manager = self.injector.get(CompanyManager)
         worker = self.member_generator.create_member(name=worker_name)
-        company_manager.add_worker_to_company(company.id, worker)
+        company_manager.add_worker_to_company(company, worker)
         response = self.client.get(URL)
         assert worker_name in response.text
 

--- a/tests/flask_integration/test_list_registered_hours_worked_view.py
+++ b/tests/flask_integration/test_list_registered_hours_worked_view.py
@@ -35,9 +35,7 @@ class CompanyTests(ViewTestCase):
         company = self.company_generator.create_company(
             workers=[worker_id], email=company_email, password=company_password
         )
-        self.login_company(
-            company=company, email=company_email, password=company_password
-        )
+        self.login_company(email=company_email, password=company_password)
         request = RegisterHoursWorkedRequest(
             company_id=company, worker_id=worker_id, hours_worked=Decimal("10")
         )

--- a/tests/flask_integration/test_member_dashboard_view.py
+++ b/tests/flask_integration/test_member_dashboard_view.py
@@ -23,7 +23,7 @@ class CompanyTest(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = "/member/dashboard"
-        self.company = self.login_company(confirm_company=True)
+        self.login_company(confirm_company=True)
 
     def test_company_gets_302(self) -> None:
         response = self.client.get(self.url)

--- a/tests/flask_integration/test_my_cooperations_view.py
+++ b/tests/flask_integration/test_my_cooperations_view.py
@@ -3,6 +3,6 @@ from .flask import ViewTestCase
 
 class CompanyViewTests(ViewTestCase):
     def test_requesting_view_as_company_results_in_200_status_code(self) -> None:
-        self.company = self.login_company()
+        self.login_company()
         response = self.client.get("/company/my_cooperations")
         self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_my_plans_view.py
+++ b/tests/flask_integration/test_my_plans_view.py
@@ -3,6 +3,6 @@ from .flask import ViewTestCase
 
 class CompanyViewTests(ViewTestCase):
     def test_requesting_view_as_company_results_in_200_status_code(self) -> None:
-        self.company = self.login_company()
+        self.login_company()
         response = self.client.get("/company/my_plans")
         self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_private_consumptions_view.py
+++ b/tests/flask_integration/test_private_consumptions_view.py
@@ -51,7 +51,7 @@ class CompanyTest(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.url = "/member/consumptions"
-        self.company = self.login_company()
+        self.login_company()
 
     def test_company_gets_redirected_to_start_page_with_next_url_set_correctly(
         self,

--- a/tests/flask_integration/test_register_hours_worked_view.py
+++ b/tests/flask_integration/test_register_hours_worked_view.py
@@ -20,7 +20,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
 
     def test_company_gets_302_when_posting_correct_data(self) -> None:
         worker = self.member_generator.create_member()
-        self.company_manager.add_worker_to_company(self.company.id, worker)
+        self.company_manager.add_worker_to_company(self.company, worker)
         response = self.client.post(
             self.url,
             data=dict(member_id=str(worker), amount="10"),
@@ -41,7 +41,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
         self,
     ) -> None:
         worker = self.member_generator.create_member()
-        self.company_manager.add_worker_to_company(self.company.id, worker)
+        self.company_manager.add_worker_to_company(self.company, worker)
         response = self.client.post(
             self.url,
             data=dict(member_id=str(worker), amount="-10"),

--- a/tests/flask_integration/test_register_productive_consumption_view.py
+++ b/tests/flask_integration/test_register_productive_consumption_view.py
@@ -6,7 +6,7 @@ from .flask import ViewTestCase
 class CompanyGetTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company()
+        self.login_company()
 
     def test_that_logged_in_company_get_200_response(self) -> None:
         response = self.client.get("/company/register_productive_consumption")
@@ -107,7 +107,7 @@ class CompanyGetTests(ViewTestCase):
 class CompanyPostTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.login_company()
+        self.login_company()
 
     def test_that_logged_in_company_receives_400_when_posting_non_existing_plan_id(
         self,

--- a/tests/flask_integration/test_request_cooperation_view.py
+++ b/tests/flask_integration/test_request_cooperation_view.py
@@ -37,7 +37,7 @@ class LoggedInCompanyTests(ViewTestCase):
     def test_get_request_shows_truncated_plan_name_and_id_of_company_plan(self) -> None:
         product_name = "product test name"
         plan = self.plan_generator.create_plan(
-            planner=self.company.id, product_name=product_name
+            planner=self.company, product_name=product_name
         )
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_request_coordination_transfer_view.py
+++ b/tests/flask_integration/test_request_coordination_transfer_view.py
@@ -41,7 +41,7 @@ class RequestCoordinationTransferTests(ViewTestCase):
     def test_company_gets_code_403_on_post_request_when_current_user_is_not_coordinator(
         self,
     ) -> None:
-        self.login_company().id
+        self.login_company()
         cooperation = self.cooperation_generator.create_cooperation()
         candidate = self.company_generator.create_company()
         data = {"candidate": str(candidate), "cooperation": str(cooperation)}
@@ -71,7 +71,7 @@ class RequestCoordinationTransferTests(ViewTestCase):
     ) -> None:
         current_user = self.login_company()
         cooperation = self.cooperation_generator.create_cooperation(
-            coordinator=current_user.id
+            coordinator=current_user
         )
         candidate_mail = "candidate@mail.org"
         candidate = self.company_generator.create_company(email=candidate_mail)
@@ -90,7 +90,7 @@ class RequestCoordinationTransferTests(ViewTestCase):
     ) -> None:
         current_user = self.login_company()
         cooperation = self.cooperation_generator.create_cooperation(
-            coordinator=current_user.id
+            coordinator=current_user
         )
         candidate_mail = "candidate@mail.org"
         candidate = self.company_generator.create_company(email=candidate_mail)

--- a/tests/flask_integration/test_show_coordination_transfer_request_view.py
+++ b/tests/flask_integration/test_show_coordination_transfer_request_view.py
@@ -82,7 +82,7 @@ class CompanyGetRequestTests(ShowTransferRequestBaseTest):
         self.assertEqual(response.status_code, 404)
 
     def test_that_200_is_returned_if_transfer_request_does_exist(self) -> None:
-        transfer_request = self.create_transfer_request(candidate=self.user.id)
+        transfer_request = self.create_transfer_request(candidate=self.user)
         url = self.create_url(transfer_request=transfer_request)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -100,9 +100,9 @@ class CompanyGetRequestTests(ShowTransferRequestBaseTest):
     def test_that_post_form_does_not_show_on_page_if_transfer_has_already_been_accepted(
         self,
     ) -> None:
-        transfer_request = self.create_transfer_request(candidate=self.user.id)
+        transfer_request = self.create_transfer_request(candidate=self.user)
         self.accept_transfer_request(
-            transfer_request=transfer_request, accepting_company=self.user.id
+            transfer_request=transfer_request, accepting_company=self.user
         )
         url = self.create_url(transfer_request=transfer_request)
         response = self.client.get(url)
@@ -111,7 +111,7 @@ class CompanyGetRequestTests(ShowTransferRequestBaseTest):
     def test_that_post_form_does_show_on_page_if_transfer_has_not_been_accepted_and_current_user_is_candidate(
         self,
     ) -> None:
-        transfer_request = self.create_transfer_request(candidate=self.user.id)
+        transfer_request = self.create_transfer_request(candidate=self.user)
         url = self.create_url(transfer_request=transfer_request)
         response = self.client.get(url)
         self.assertIn('<form method="post">', response.text)
@@ -130,7 +130,7 @@ class CompanyPostRequestTests(ShowTransferRequestBaseTest):
     def test_that_302_is_returned_if_transfer_request_exists_and_user_is_candidate(
         self,
     ) -> None:
-        transfer_request = self.create_transfer_request(candidate=self.user.id)
+        transfer_request = self.create_transfer_request(candidate=self.user)
         url = self.create_url(transfer_request=transfer_request)
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
@@ -148,9 +148,9 @@ class CompanyPostRequestTests(ShowTransferRequestBaseTest):
     def test_that_409_is_returned_if_transfer_request_exists_but_request_has_already_been_accepted(
         self,
     ) -> None:
-        transfer_request = self.create_transfer_request(candidate=self.user.id)
+        transfer_request = self.create_transfer_request(candidate=self.user)
         self.accept_transfer_request(
-            transfer_request=transfer_request, accepting_company=self.user.id
+            transfer_request=transfer_request, accepting_company=self.user
         )
         url = self.create_url(transfer_request=transfer_request)
         response = self.client.post(url)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -48,32 +48,26 @@ class PlotUrlIndexTests(ViewTestCase):
 
     def test_url_for_lineplot_for_companies_own_prd_account_returns_png(self) -> None:
         url = self.url_index.get_line_plot_of_company_prd_account(
-            company_id=self.company.id
+            company_id=self.company
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "image/png")
 
     def test_url_for_lineplot_for_companies_own_r_account_returns_png(self) -> None:
-        url = self.url_index.get_line_plot_of_company_r_account(
-            company_id=self.company.id
-        )
+        url = self.url_index.get_line_plot_of_company_r_account(company_id=self.company)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "image/png")
 
     def test_url_for_lineplot_for_companies_own_p_account_returns_png(self) -> None:
-        url = self.url_index.get_line_plot_of_company_p_account(
-            company_id=self.company.id
-        )
+        url = self.url_index.get_line_plot_of_company_p_account(company_id=self.company)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "image/png")
 
     def test_url_for_lineplot_for_companies_own_a_account_returns_png(self) -> None:
-        url = self.url_index.get_line_plot_of_company_a_account(
-            company_id=self.company.id
-        )
+        url = self.url_index.get_line_plot_of_company_a_account(company_id=self.company)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "image/png")
@@ -139,7 +133,7 @@ class GeneralUrlIndexTests(ViewTestCase):
         self,
     ) -> None:
         company = self.login_company()
-        draft = self.plan_generator.draft_plan(planner=company.id)
+        draft = self.plan_generator.draft_plan(planner=company)
         url = self.url_index.get_draft_details_url(draft_id=draft)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -377,7 +371,7 @@ class GeneralUrlIndexTests(ViewTestCase):
     def test_get_request_to_show_coordination_transfer_request_url_leads_to_functional_url(
         self,
     ) -> None:
-        current_user = self.login_company().id
+        current_user = self.login_company()
         coop_id = self.cooperation_generator.create_cooperation(
             coordinator=current_user
         )
@@ -393,7 +387,7 @@ class GeneralUrlIndexTests(ViewTestCase):
     def test_post_request_by_assignated_candidate_to_show_coordination_transfer_request_url_leads_to_functional_url(
         self,
     ) -> None:
-        candidate = self.login_company().id
+        candidate = self.login_company()
         coordinator = self.company_generator.create_company()
         coop_id = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         transfer_request_id = self.coordination_transfer_request_generator.create_coordination_transfer_request(


### PR DESCRIPTION
**Improve login of users in our integration test framework** 

Before this change it was possible to specify member (or company) as well as password and email, when loging in users in the `ViewTestCase` of our test framework. This was confusing, because the user's credentials might not be compatible with the specified user id. The design has been improved.

**Let ViewTestCase.login_company return a UUID** 

Before this change the helper method `ViewTestCase.login_company`, used in many places of our integration tests, returned a `Company` record object, now it returns a UUID.