### PR TITLE
Remove usage of flask restx `RequestParser`

### DIFF
--- a/arbeitszeit_flask/api/input_documentation.py
+++ b/arbeitszeit_flask/api/input_documentation.py
@@ -4,7 +4,7 @@ from flask_restx import Namespace
 from flask_restx.reqparse import RequestParser
 
 from arbeitszeit_web.api.controllers.parameters import (
-    FormParameter,
+    BodyParameter,
     PathParameter,
     QueryParameter,
 )
@@ -13,7 +13,7 @@ from arbeitszeit_web.api.controllers.parameters import (
 class with_input_documentation:
     def __init__(
         self,
-        expected_inputs: Sequence[QueryParameter | FormParameter | PathParameter],
+        expected_inputs: Sequence[QueryParameter | BodyParameter | PathParameter],
         namespace: Namespace,
     ) -> None:
         self._expected_inputs = expected_inputs
@@ -41,7 +41,7 @@ class with_input_documentation:
         decorator(func)
 
     def _add_argument_to_parser(
-        self, parser: RequestParser, input: FormParameter | QueryParameter
+        self, parser: RequestParser, input: BodyParameter | QueryParameter
     ) -> RequestParser:
         location = "query" if isinstance(input, QueryParameter) else "json"
         return parser.add_argument(

--- a/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
+++ b/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
@@ -5,21 +5,21 @@ from arbeitszeit.records import ConsumptionType
 from arbeitszeit.use_cases.register_productive_consumption import (
     RegisterProductiveConsumptionRequest as UseCaseRequest,
 )
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest, Unauthorized
 from arbeitszeit_web.json import JsonValue
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.session import Session, UserRole
 
 liquid_means_expected_inputs = [
-    FormParameter(
+    BodyParameter(
         name="plan_id",
         type=str,
         description="The plan to consume.",
         default=None,
         required=True,
     ),
-    FormParameter(
+    BodyParameter(
         name="amount",
         type=int,
         description="The amount of product to consume.",

--- a/arbeitszeit_web/api/controllers/login_company_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_company_api_controller.py
@@ -1,17 +1,17 @@
 from arbeitszeit.use_cases.log_in_company import LogInCompanyUseCase
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest
 from arbeitszeit_web.request import Request
 
 login_company_expected_inputs = [
-    FormParameter(
+    BodyParameter(
         name="email",
         type=str,
         description="Email.",
         default=None,
         required=True,
     ),
-    FormParameter(
+    BodyParameter(
         name="password",
         type=str,
         description="Password.",

--- a/arbeitszeit_web/api/controllers/login_member_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_member_api_controller.py
@@ -1,19 +1,19 @@
 from dataclasses import dataclass
 
 from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest
 from arbeitszeit_web.request import Request
 
 login_member_expected_inputs = [
-    FormParameter(
+    BodyParameter(
         name="email",
         type=str,
         description="Email.",
         default=None,
         required=True,
     ),
-    FormParameter(
+    BodyParameter(
         name="password",
         type=str,
         description="Password.",

--- a/arbeitszeit_web/api/controllers/parameters.py
+++ b/arbeitszeit_web/api/controllers/parameters.py
@@ -3,7 +3,7 @@ from typing import Type, Union
 
 
 @dataclass
-class FormParameter:
+class BodyParameter:
     name: str
     type: Type
     description: str

--- a/tests/api/controllers/test_liquid_means_consumption_controller.py
+++ b/tests/api/controllers/test_liquid_means_consumption_controller.py
@@ -7,7 +7,7 @@ from arbeitszeit_web.api.controllers.liquid_means_consumption_controller import 
     LiquidMeansConsumptionController,
     liquid_means_expected_inputs,
 )
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest, Unauthorized
 from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
@@ -168,9 +168,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[0]
         self.assertEqual(input.name, "plan_id")
 
-    def test_input_plan_id_is_of_type_form_param(self):
+    def test_input_plan_id_is_of_type_body_param(self):
         input = self.inputs[0]
-        assert isinstance(input, FormParameter)
+        assert isinstance(input, BodyParameter)
 
     def test_input_plan_id_has_correct_parameters(self):
         input = self.inputs[0]
@@ -184,9 +184,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[1]
         self.assertEqual(input.name, "amount")
 
-    def test_input_amount_is_of_type_form_param(self):
+    def test_input_amount_is_of_type_body_param(self):
         input = self.inputs[1]
-        assert isinstance(input, FormParameter)
+        assert isinstance(input, BodyParameter)
 
     def test_input_amount_has_correct_parameters(self):
         input = self.inputs[1]

--- a/tests/api/controllers/test_login_company_api_controller.py
+++ b/tests/api/controllers/test_login_company_api_controller.py
@@ -2,7 +2,7 @@ from arbeitszeit_web.api.controllers.login_company_api_controller import (
     LoginCompanyApiController,
     login_company_expected_inputs,
 )
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest
 from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
@@ -59,9 +59,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[0]
         self.assertEqual(input.name, "email")
 
-    def test_input_email_is_form_param(self) -> None:
+    def test_input_email_is_body_param(self) -> None:
         input = self.inputs[0]
-        assert isinstance(input, FormParameter)
+        assert isinstance(input, BodyParameter)
 
     def test_input_email_has_correct_parameters(self) -> None:
         input = self.inputs[0]
@@ -75,9 +75,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[1]
         self.assertEqual(input.name, "password")
 
-    def test_input_password_is_form_param(self) -> None:
+    def test_input_password_is_body_param(self) -> None:
         input = self.inputs[1]
-        assert isinstance(input, FormParameter)
+        assert isinstance(input, BodyParameter)
 
     def test_input_limit_has_correct_parameters(self) -> None:
         input = self.inputs[1]

--- a/tests/api/controllers/test_login_member_api_controller.py
+++ b/tests/api/controllers/test_login_member_api_controller.py
@@ -2,7 +2,7 @@ from arbeitszeit_web.api.controllers.login_member_api_controller import (
     LoginMemberApiController,
     login_member_expected_inputs,
 )
-from arbeitszeit_web.api.controllers.parameters import FormParameter
+from arbeitszeit_web.api.controllers.parameters import BodyParameter
 from arbeitszeit_web.api.response_errors import BadRequest
 from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
@@ -59,9 +59,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[0]
         self.assertEqual(input.name, "email")
 
-    def test_input_email_is_form_param(self) -> None:
+    def test_input_email_is_body_param(self) -> None:
         input = self.inputs[0]
-        self.assertIsInstance(input, FormParameter)
+        self.assertIsInstance(input, BodyParameter)
 
     def test_input_email_has_correct_parameters(self) -> None:
         input = self.inputs[0]
@@ -75,9 +75,9 @@ class ExpectedInputsTests(BaseTestCase):
         input = self.inputs[1]
         self.assertEqual(input.name, "password")
 
-    def test_input_limit_is_form_param(self) -> None:
+    def test_input_limit_is_body_param(self) -> None:
         input = self.inputs[1]
-        self.assertIsInstance(input, FormParameter)
+        self.assertIsInstance(input, BodyParameter)
 
     def test_input_limit_has_correct_parameters(self) -> None:
         input = self.inputs[1]


### PR DESCRIPTION
**Rename Api FormParameter to BodyParameter** 

This is a better name for the parameter in question. Its location is the body of a request and is to be distinguished from a Form parameter. See swagger v2 specs.

**Refactor Api docu decorator** 

This commit refactors the decorator `with_input_documentation`, which is responsible for generating the API documentation of the expected parameters. Now the decorator does not rely on the deprecated flask restx `RequestParser` anymore.

fixes #1111 

_FYI, a good tool to check the generated swagger.json document (http://127.0.0.1:5000/api/v1/swagger.json) for errors is https://editor.swagger.io/_