### PR TITLE
Rework cooperative price calculation

### DIFF
--- a/arbeitszeit/plan_details.py
+++ b/arbeitszeit/plan_details.py
@@ -51,11 +51,10 @@ class PlanDetailsService:
         if not plan_and_cooperation:
             return None
         plan, cooperation = plan_and_cooperation
-        labour_cost_per_unit = self.price_calculator.individual_labour_cost(plan)
         if plan.is_active_as_of(now):
             price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
         else:
-            price_per_unit = self.price_calculator.calculate_individual_price(plan)
+            price_per_unit = plan.price_per_unit()
         planner = self.database_gateway.get_companies().with_id(plan.planner).first()
         assert planner
         return PlanDetails(
@@ -74,7 +73,7 @@ class PlanDetailsService:
             labour_cost=plan.production_costs.labour_cost,
             is_public_service=plan.is_public_service,
             price_per_unit=price_per_unit,
-            labour_cost_per_unit=labour_cost_per_unit,
+            labour_cost_per_unit=plan.cost_per_unit(),
             is_cooperating=bool(cooperation),
             cooperation=cooperation.id if cooperation else None,
             creation_date=plan.plan_creation_date,

--- a/arbeitszeit/price_calculator.py
+++ b/arbeitszeit/price_calculator.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable, List
+from typing import Iterable
 
 from arbeitszeit import records
 from arbeitszeit.datetime_service import DatetimeService
@@ -14,50 +14,23 @@ class PriceCalculator:
 
     def calculate_cooperative_price(self, plan: records.Plan) -> Decimal:
         now = self.datetime_service.now()
-        if plan.is_public_service:
-            return Decimal(0)
-        if plan.is_expired_as_of(now):
-            return self.calculate_individual_price(plan)
         plans = list(
             self.database_gateway.get_plans()
             .that_are_in_same_cooperation_as(plan.id)
             .that_will_expire_after(now)
         )
         if not plans:
-            return self.calculate_individual_price(plan)
+            return plan.price_per_unit()
         elif len(plans) == 1:
-            return self.calculate_individual_price(plans[0])
+            return plans[0].price_per_unit()
         else:
-            return self._calculate_coop_price(plans)
+            return self._calculate_average_costs(plans)
 
-    def calculate_individual_price(self, plan: records.Plan) -> Decimal:
-        return calculate_individual_price(plan)
-
-    def individual_labour_cost(self, plan: records.Plan) -> Decimal:
-        return individual_labour_cost(plan)
-
-    def _calculate_coop_price(self, plans: List[records.Plan]) -> Decimal:
+    def _calculate_average_costs(self, plans: Iterable[records.Plan]) -> Decimal:
+        if not isinstance(plans, list):
+            plans = list(plans)
         assert not any(plan.is_public_service for plan in plans)
-        return calculate_average_costs([p.to_summary() for p in plans])
+        if not plans:
+            return Decimal(0)
 
-
-def calculate_individual_price(plan: records.Plan) -> Decimal:
-    if plan.is_public_service:
-        return Decimal(0)
-    return individual_labour_cost(plan)
-
-
-def individual_labour_cost(plan: records.Plan) -> Decimal:
-    return plan.production_costs.total_cost() / plan.prd_amount
-
-
-def calculate_average_costs(plans: Iterable[records.PlanSummary]) -> Decimal:
-    cost_by_time = Decimal(0)
-    amount_by_time = Decimal(0)
-    for plan in plans:
-        cost_by_time += plan.production_costs / Decimal(plan.duration_in_days)
-        amount_by_time += Decimal(plan.amount) / Decimal(plan.duration_in_days)
-    if not amount_by_time:
-        return Decimal(0)
-    else:
-        return cost_by_time / amount_by_time
+        return sum(plan.cost_per_unit() for plan in plans) / len(plans)

--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -266,6 +266,14 @@ class Plan:
             amount=self.prd_amount,
         )
 
+    def cost_per_unit(self) -> Decimal:
+        if self.prd_amount == 0:
+            return Decimal(0)
+        return self.production_costs.total_cost() / Decimal(self.prd_amount)
+
+    def price_per_unit(self) -> Decimal:
+        return Decimal(0) if self.is_public_service else self.cost_per_unit()
+
 
 class ConsumptionType(Enum):
     means_of_prod = "means_of_prod"

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -2,17 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import (
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Protocol,
-    Self,
-    Tuple,
-    TypeVar,
-)
+from typing import Generic, Iterable, Iterator, Optional, Protocol, Self, Tuple, TypeVar
 from uuid import UUID
 
 from arbeitszeit import records
@@ -85,10 +75,15 @@ class PlanResult(QueryResult[records.Plan], Protocol):
         self, *, cooperation: Optional[UUID] = ...
     ) -> Self: ...
 
-    def that_are_in_same_cooperation_as(self, plan: UUID) -> Self: ...
+    def that_are_in_same_cooperation_as(self, plan: UUID) -> Self:
+        """Returns all plans that are part of the same cooperation as
+        the plan specified by the UUID argument, including the plan
+        itself. If the plan is not part of any cooperation then the
+        result will be empty.
+        """
 
     def that_are_part_of_cooperation(self, *cooperation: UUID) -> Self:
-        """If no cooperations are specified, then all the repository
+        """If no cooperations are specified, then the repository
         should return plans that are part of any cooperation.
         """
 
@@ -108,14 +103,11 @@ class PlanResult(QueryResult[records.Plan], Protocol):
         only contain plans that are not hidden.
         """
 
-    def joined_with_planner_and_cooperation_and_cooperating_plans(
-        self, timestamp: datetime
-    ) -> QueryResult[
+    def joined_with_planner_and_cooperation(self) -> QueryResult[
         Tuple[
             records.Plan,
             records.Company,
             Optional[records.Cooperation],
-            List[records.PlanSummary],
         ]
     ]: ...
 

--- a/arbeitszeit/use_cases/get_coop_summary.py
+++ b/arbeitszeit/use_cases/get_coop_summary.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.price_calculator import PriceCalculator, calculate_average_costs
+from arbeitszeit.price_calculator import PriceCalculator
 from arbeitszeit.records import Plan
 from arbeitszeit.repositories import DatabaseGateway
 
@@ -81,8 +81,7 @@ class GetCoopSummary:
     def _get_cooperative_price(self, plans: list[Plan]) -> Optional[Decimal]:
         if not plans:
             return None
-        coop_price = calculate_average_costs(plans=[p.to_summary() for p in plans])
-        return coop_price
+        return self.price_calculator.calculate_cooperative_price(plans[0])
 
     def _get_associated_plans(
         self, plans: list[Plan], requester: UUID
@@ -91,9 +90,7 @@ class GetCoopSummary:
             AssociatedPlan(
                 plan_id=plan.id,
                 plan_name=plan.prd_name,
-                plan_individual_price=self.price_calculator.calculate_individual_price(
-                    plan
-                ),
+                plan_individual_price=plan.price_per_unit(),
                 planner_id=plan.planner,
                 planner_name=self._get_planner_name(plan.planner),
                 requester_is_planner=plan.planner == requester,

--- a/arbeitszeit/use_cases/register_private_consumption.py
+++ b/arbeitszeit/use_cases/register_private_consumption.py
@@ -65,15 +65,12 @@ class RegisterPrivateConsumption:
                 rejection_reason=RejectionReason.consumer_does_not_exist
             )
         coop_price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
-        individual_price_per_unit = self.price_calculator.calculate_individual_price(
-            plan
-        )
         transaction = self._transfer_certificates(
             request.amount,
             plan,
             consumer,
             coop_price_per_unit=coop_price_per_unit,
-            individual_price_per_unit=individual_price_per_unit,
+            individual_price_per_unit=plan.price_per_unit(),
         )
         self.database_gateway.create_private_consumption(
             amount=request.amount,

--- a/arbeitszeit/use_cases/register_productive_consumption.py
+++ b/arbeitszeit/use_cases/register_productive_consumption.py
@@ -109,9 +109,7 @@ class RegisterProductiveConsumption:
         plan: Plan,
     ) -> None:
         coop_price = amount * self.price_calculator.calculate_cooperative_price(plan)
-        individual_price = amount * self.price_calculator.calculate_individual_price(
-            plan
-        )
+        individual_price = amount * plan.price_per_unit()
         if consumption_type == ConsumptionType.means_of_prod:
             sending_account = consumer.means_account
         elif consumption_type == ConsumptionType.raw_materials:

--- a/docs/development_guide.rst
+++ b/docs/development_guide.rst
@@ -812,23 +812,45 @@ More info, concerning the ``icon`` filter implementation, can be found in
 Cooperations 
 -------------
 
-Companies that produce the same product can attach their plans to so-called "cooperations".
-Plans in a cooperation share a unified, averaged "cooperation price" for consumption. Apart 
-from that, they remain, technically speaking, independent plans of independent companies.
+Companies that produce the same product can attach their plans to so-called 
+"cooperations". The purpose of a cooperation is to calculate the average 
+labor cost per product within a specific branch or industry. This 
+average labor cost, known as the cooperative price, is what customers will pay for a 
+product. It is displayed in several places in the application.
 
-**Coordinators of cooperations**
+**Cooperative Price**
 
-"Empty" cooperations (without any plans attached) can be created by any company. The company
-that creates a cooperation automatically becomes the "coordinator" of that cooperation. A
-coordinator has several privileges and duties: They can accept or deny incoming cooperation requests,
-remove plans from the cooperation, or transfer the coordination role to another company. 
-The history of past coordinators is transparent to all users.
+The logic for calculating the cooperative price is implemented in the module 
+``arbeitszeit/price_calculator.py``. The cooperative price is determined 
+as the average cost per product of all plans in the cooperation. 
+The formula for the cooperative price is:
 
-While this implementation may seem undemocratic, it must be noted that the Arbeitszeitapp
-only provides the technical front-end to diverse democratic processes that must happen in "real life".
-The app does not prescribe the democratic procedures that companies and communities choose to 
+.. math::
+
+  \text{cooperative price} = \frac{1}{n} \sum_{i=1}^{n} \frac{\text{cost}_i}{\text{pieces}_i}
+
+where :math:`\text{cost}_i` is the total cost of the :math:`i`-th plan in the
+cooperation and :math:`\text{pieces}_i` is the total amount of produced pieces
+of the :math:`i`-th plan. The sum runs over all :math:`n` plans in the cooperation.
+
+Note that the cooperative price is independent of the duration of the plans.
+Whether one working hour was applied in one year or in one day, 
+the price will be one hour.
+
+**Coordinators of Cooperations**
+
+"Empty" cooperations (without any plans attached) can be created by any 
+company. The company that creates a cooperation automatically becomes the 
+"coordinator" of that cooperation. A coordinator has several privileges and 
+duties: They can accept or deny incoming cooperation requests,
+remove plans from the cooperation, or transfer the coordination role to 
+another company. The history of past coordinator tenures is visible to all users.
+
+While this implementation may seem undemocratic at first glance, it must be noted that the Arbeitszeitapp
+only provides the technical front-end to diverse political processes that must happen in "real life".
+The app does not prescribe the political procedures that companies and communities choose to 
 elect coordinators or to define cooperations. Because every company is able to create cooperations, 
-companies that are unhappy with a certain coordination can easily form a new cooperation. 
+companies that are unhappy with a certain coordination can easily form a new cooperation.
 
 .. _Liskov Substitution Principle: https://en.wikipedia.org/wiki/Liskov_substitution_principle
 .. _flask blueprints: https://flask.palletsprojects.com/en/latest/blueprints/

--- a/tests/services/test_price_calculator.py
+++ b/tests/services/test_price_calculator.py
@@ -1,0 +1,166 @@
+from decimal import Decimal
+
+from parameterized import parameterized
+
+from arbeitszeit.price_calculator import PriceCalculator
+from arbeitszeit.records import ProductionCosts
+from tests.use_cases.base_test_case import BaseTestCase
+
+
+class PriceCalculatorTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.calculator = self.injector.get(PriceCalculator)
+
+    def test_that_price_of_one_public_plan_is_zero(self) -> None:
+        public_plan = self.plan_generator.create_plan_record(is_public_service=True)
+        price = self.calculator.calculate_cooperative_price(public_plan)
+        assert price == Decimal(0)
+
+    def test_that_price_of_one_plan_that_produces_zero_units_is_zero(self) -> None:
+        plan = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+            amount=0,
+        )
+        price = self.calculator.calculate_cooperative_price(plan)
+        assert price == Decimal(0)
+
+    def test_that_price_is_zero_when_all_plans_in_cooperation_produce_zero_units(
+        self,
+    ) -> None:
+        plan_1 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+            amount=0,
+        )
+        plan_2 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+            amount=0,
+        )
+        self.cooperation_generator.create_cooperation(
+            plans=[plan_1.id, plan_2.id],
+        )
+        price = self.calculator.calculate_cooperative_price(plan_1)
+        assert price == Decimal(0)
+
+    @parameterized.expand(
+        [
+            (Decimal(10),),
+            (Decimal(20),),
+        ]
+    )
+    def test_that_price_of_plan_without_cooperation_is_its_own_costs(
+        self,
+        costs: Decimal,
+    ) -> None:
+        plan = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        price = self.calculator.calculate_cooperative_price(plan)
+        self.assertAlmostEqual(price, costs)
+
+    @parameterized.expand(
+        [
+            (Decimal(10),),
+            (Decimal(20),),
+        ]
+    )
+    def test_that_price_of_plan_that_is_sole_cooperation_member_equals_its_own_costs(
+        self,
+        costs: Decimal,
+    ) -> None:
+        plan = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        self.cooperation_generator.create_cooperation(plans=[plan.id])
+        price = self.calculator.calculate_cooperative_price(plan)
+        self.assertAlmostEqual(price, costs)
+
+    @parameterized.expand(
+        [
+            (Decimal(10), Decimal(20), Decimal(15)),
+            (Decimal(20), Decimal(30), Decimal(25)),
+        ]
+    )
+    def test_that_cooperative_price_for_two_companies_is_average_of_costs(
+        self,
+        costs_1: Decimal,
+        costs_2: Decimal,
+        expected_price: Decimal,
+    ) -> None:
+        plan_1 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        plan_2 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        self.cooperation_generator.create_cooperation(
+            plans=[plan_1.id, plan_2.id],
+        )
+        price = self.calculator.calculate_cooperative_price(plan_1)
+        self.assertAlmostEqual(price, expected_price)
+
+    @parameterized.expand(
+        [
+            (Decimal(10), Decimal(20), Decimal(30), Decimal(20)),
+            (Decimal(20), Decimal(30), Decimal(40), Decimal(30)),
+        ]
+    )
+    def test_that_cooperative_price_for_three_companies_is_average_of_costs(
+        self,
+        costs_1: Decimal,
+        costs_2: Decimal,
+        costs_3: Decimal,
+        expected_price: Decimal,
+    ) -> None:
+        plan_1 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        plan_2 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        plan_3 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_3, Decimal(0), Decimal(0)),
+            amount=1,
+        )
+        self.cooperation_generator.create_cooperation(
+            plans=[plan_1.id, plan_2.id, plan_3.id],
+        )
+        price = self.calculator.calculate_cooperative_price(plan_1)
+        self.assertAlmostEqual(price, expected_price)
+
+    @parameterized.expand(
+        [
+            (Decimal(1), 1, Decimal(3), 1, Decimal(2)),
+            (Decimal(1), 38, Decimal(3), 1, Decimal(2)),
+            (Decimal(1), 1, Decimal(3), 72, Decimal(2)),
+        ]
+    )
+    def test_that_cooperative_price_for_two_companies_is_average_of_costs_independent_of_duration(
+        self,
+        costs_1: Decimal,
+        duration_1: int,
+        costs_2: Decimal,
+        duration_2: int,
+        expected_price: Decimal,
+    ) -> None:
+        plan_1 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
+            amount=1,
+            timeframe=duration_1,
+        )
+        plan_2 = self.plan_generator.create_plan_record(
+            costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
+            amount=1,
+            timeframe=duration_2,
+        )
+        self.cooperation_generator.create_cooperation(
+            plans=[plan_1.id, plan_2.id],
+        )
+        price = self.calculator.calculate_cooperative_price(plan_1)
+        self.assertAlmostEqual(price, expected_price)


### PR DESCRIPTION
**Rework cooperative price calculation** 

Before this commit, the cooperative price calculation was dependent on the plan durations. Specifically, plan costs were inversely weighted by plan duration, meaning that shorter plans had a greater impact on the coop price than longer running plans. The reasoning behind this was that shorter plans would be renewed more often and contribute more labor time to the cooperation's product.

This commit proposes to reject this original reasoning. We think it made to many unnecessary assumptions on the plans in a cooperation. Instead, we argue that the cooperative price should simply reflect the relation between costs (in labor time) and amount of produced units in a cooperation at a specific point in time. A section explaining the current calculation logic has been added to the development guide.

The module `arbeitszeit/price_calculator.py` has been significantly simplified. This was possible in part because two new methods have been added to the `Plan` class in `arbeitszeit/records.py`: `Plan.cost_per_unit` and `Plan.price_per_unit`.

Moreover, because of changes in the price calculator module, the repository method `joined_with_planner_and_cooperation_and_cooperating_plans` could be simplified to `joined_with_planner_and_cooperation`.

Fixes #1143