### PR TITLE
Small changes to draft details and draft edit

### DIFF
--- a/arbeitszeit/use_cases/get_draft_details.py
+++ b/arbeitszeit/use_cases/get_draft_details.py
@@ -9,7 +9,6 @@ from arbeitszeit.repositories import DatabaseGateway
 
 @dataclass
 class DraftDetailsSuccess:
-    draft_id: UUID
     planner_id: UUID
     product_name: str
     description: str
@@ -35,7 +34,6 @@ class GetDraftDetails:
         if draft is None:
             return None
         return DraftDetailsSuccess(
-            draft_id=draft.id,
             planner_id=draft.planner,
             product_name=draft.product_name,
             description=draft.description,

--- a/arbeitszeit_flask/templates/company/draft_details.html
+++ b/arbeitszeit_flask/templates/company/draft_details.html
@@ -19,18 +19,13 @@
         <div class="block py-2"></div>
         <div class="field is-grouped is-grouped-centered">
           <div class="control">
-            <button class="button is-primary is-light"
-                    name="action"
-                    value="save_draft"
-                    type="submit"
-                    formaction="{{ save_draft_url }}">
+            <button class="button is-primary is-light" type="submit">
               {{ gettext("Save draft")}}
             </button>
           </div>
           <div class="control">
             <div class="control">
-              <a class="button is-light"
-                 href="{{ cancel_url }}">
+              <a class="button is-light" href="{{ cancel_url }}">
                 {{ gettext("Cancel")}}
               </a>
             </div>

--- a/arbeitszeit_flask/views/draft_details_view.py
+++ b/arbeitszeit_flask/views/draft_details_view.py
@@ -37,7 +37,6 @@ class DraftDetailsView:
             render_template(
                 "company/draft_details.html",
                 cancel_url=view_model.cancel_url,
-                save_draft_url=view_model.save_draft_url,
                 form=form,
             )
         )
@@ -66,7 +65,6 @@ class DraftDetailsView:
         return FlaskResponse(
             render_template(
                 "company/draft_details.html",
-                save_draft_url="",
                 cancel_url=self.url_index.get_my_plans_url(),
                 form=form,
             ),

--- a/arbeitszeit_web/www/presenters/edit_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/edit_draft_presenter.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from arbeitszeit.use_cases.edit_draft import Response
+from arbeitszeit.use_cases import edit_draft
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 
 
@@ -12,9 +14,24 @@ class ViewModel:
 @dataclass
 class EditDraftPresenter:
     url_index: UrlIndex
+    translator: Translator
+    notifier: Notifier
 
-    def render_response(self, response: Response) -> ViewModel:
-        if response.is_success:
-            return ViewModel(redirect_url=self.url_index.get_my_plans_url())
-        else:
-            return ViewModel(redirect_url=None)
+    def render_response(self, response: edit_draft.Response) -> ViewModel:
+        match response.rejection_reason:
+            case edit_draft.Response.RejectionReason.NOT_FOUND:
+                self.notifier.display_warning(
+                    self.translator.gettext(
+                        "The draft you are trying to edit does not exist."
+                    )
+                )
+                return ViewModel(redirect_url=None)
+            case edit_draft.Response.RejectionReason.UNAUTHORIZED:
+                self.notifier.display_warning(
+                    self.translator.gettext(
+                        "You are not authorized to edit this draft."
+                    )
+                )
+                return ViewModel(redirect_url=None)
+            case None:
+                return ViewModel(redirect_url=self.url_index.get_my_plans_url())

--- a/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
@@ -12,7 +12,6 @@ from arbeitszeit_web.url_index import UrlIndex
 class GetDraftDetailsPresenter:
     @dataclass
     class ViewModel:
-        save_draft_url: str
         cancel_url: str
 
     url_index: UrlIndex
@@ -20,10 +19,6 @@ class GetDraftDetailsPresenter:
     def present_draft_details(
         self, draft_data: PlanDetails | DraftDetailsSuccess, form: DraftForm
     ) -> ViewModel:
-        if isinstance(draft_data, PlanDetails):
-            draft_id = draft_data.plan_id
-        else:
-            draft_id = draft_data.draft_id
         form.product_name_field().set_value(draft_data.product_name)
         form.description_field().set_value(draft_data.description)
         form.timeframe_field().set_value(draft_data.timeframe)
@@ -34,6 +29,5 @@ class GetDraftDetailsPresenter:
         form.labour_cost_field().set_value(draft_data.labour_cost)
         form.is_public_service_field().set_value(draft_data.is_public_service)
         return self.ViewModel(
-            save_draft_url=self.url_index.get_draft_details_url(draft_id),
             cancel_url=self.url_index.get_my_plans_url(),
         )

--- a/tests/www/presenters/test_edit_draft_presenter.py
+++ b/tests/www/presenters/test_edit_draft_presenter.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from arbeitszeit.use_cases.edit_draft import Response
 from arbeitszeit_web.www.presenters.edit_draft_presenter import EditDraftPresenter
 from tests.www.base_test_case import BaseTestCase
@@ -8,12 +10,25 @@ class EditDraftPresenterTests(BaseTestCase):
         super().setUp()
         self.presenter = self.injector.get(EditDraftPresenter)
 
-    def test_unsuccessful_response_leads_to_redirect_url_being_none(self) -> None:
-        view_model = self.presenter.render_response(response=Response(is_success=False))
+    @parameterized.expand(
+        [
+            (Response.RejectionReason.NOT_FOUND,),
+            (Response.RejectionReason.UNAUTHORIZED,),
+        ]
+    )
+    def test_unsuccessful_response_leads_to_redirect_url_being_none(
+        self,
+        rejection_reason: Response.RejectionReason,
+    ) -> None:
+        view_model = self.presenter.render_response(
+            response=Response(rejection_reason=rejection_reason)
+        )
         assert view_model.redirect_url is None
 
     def test_that_successful_response_leads_to_redirect_url_pointing_to_my_plans_view(
         self,
     ) -> None:
-        view_model = self.presenter.render_response(response=Response(is_success=True))
+        view_model = self.presenter.render_response(
+            response=Response(rejection_reason=None)
+        )
         assert view_model.redirect_url == self.url_index.get_my_plans_url()

--- a/tests/www/presenters/test_get_draft_details_presenter.py
+++ b/tests/www/presenters/test_get_draft_details_presenter.py
@@ -11,7 +11,6 @@ from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
 
 TEST_DRAFT_SUMMARY_SUCCESS = DraftDetailsSuccess(
-    draft_id=uuid4(),
     planner_id=uuid4(),
     product_name="test draft",
     description="beschreibung draft",
@@ -58,10 +57,6 @@ class PlanDetailsPresenterTests(BaseTestCase):
         form = DraftForm()
         view_model = self.presenter.present_draft_details(self.plan_details, form=form)
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
-        self.assertEqual(
-            view_model.save_draft_url,
-            self.url_index.get_draft_details_url(self.plan_details.plan_id),
-        )
 
 
 class DraftDetailsPresenterTests(BaseTestCase):
@@ -113,7 +108,3 @@ class DraftDetailsPresenterTests(BaseTestCase):
             TEST_DRAFT_SUMMARY_SUCCESS, form=form
         )
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
-        self.assertEqual(
-            view_model.save_draft_url,
-            self.url_index.get_draft_details_url(TEST_DRAFT_SUMMARY_SUCCESS.draft_id),
-        )


### PR DESCRIPTION
The following two commits are preliminary work for #945:

**Delete unnecessary `save_draft_url` in `draft_details.html`** 

This variable in the html form is a relic from past implementations.

**Improve `EditDraftUseCase` by returning rejection reasons**