### PR TITLE
Add alembic.ini to MANIFEST.in for inclusion in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ recursive-include arbeitszeit_flask/templates *.html
 recursive-include arbeitszeit_flask/migrations *.ini *.mako *.py
 recursive-include arbeitszeit_flask/static *.js *.css
 recursive-include arbeitszeit_flask/translations *.po *.mo *.pot
+include alembic.ini
 prune build/
 prune .git/


### PR DESCRIPTION
Our deployment tests are currently failing. This PR should fix it. 

Output of `nix flake check` in repository `arbeitszeit-deployment`:

```bash
machine # [   23.183504] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/arbeitszeit_flask/wsgi.py", line 3, in <modu>
machine # [   23.188221] uwsgi[975]:     app = create_app()
machine # [   23.189692] uwsgi[975]:           ^^^^^^^^^^^^
machine # [   23.192629] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/arbeitszeit_flask/__init__.py", line 80, in >
machine # [   23.197736] uwsgi[975]:     alembic_command.upgrade(alembic_cfg, "head")
machine # [   23.200320] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/alembic/command.py", line 383, in upgrade
machine # [   23.204663] uwsgi[975]:     script = ScriptDirectory.from_config(config)
machine # [   23.206291] uwsgi[975]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine # [   23.208840] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/alembic/script/base.py", line 169, in from_c>
machine # [   23.217270] uwsgi[975]:     script_location = config.get_main_option("script_location")
machine # [   23.220594] uwsgi[975]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine # [   23.224465] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/alembic/config.py", line 335, in get_main_op>
machine # [   23.230938] uwsgi[975]:     return self.get_section_option(self.config_ini_section, name, default)
machine # [   23.234722] uwsgi[975]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine # [   23.238383] uwsgi[975]:   File "/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-packages/alembic/config.py", line 306, in get_section>
machine # [   23.244987] uwsgi[975]:     raise util.CommandError(
machine # [   23.247748] uwsgi[975]: alembic.util.exc.CommandError: No config file PosixPath('/nix/store/3w7gq1xrqymlg9wc2i2ga4f1v0izqdn7-python3-3.11.10-env/lib/python3.11/site-pack>
machine # [   23.255321] uwsgi[975]: unable to load app 0 (mountpoint='') (callable not found or import error)
machine # [   23.258326] uwsgi[975]: *** no app loaded. GAME OVER ***
machine # [   23.264664] uwsgi[973]: Tue Dec 31 18:42:42 2024 - [emperor] curse the uwsgi instance arbeitszeitapp.json (pid: 975)
machine # [   23.268731] nginx[823]: 2024/12/31 18:42:42 [error] 823#823: *2 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: ::1, s>
machine # < HTTP/1.1 502 Bad Gateway
machine # < Server: nginx
machine # < Date: Tue, 31 Dec 2024 18:42:42 GMT
machine # < Content-Type: text/html
machine # < Content-Length: 150
machine # < Connection: keep-alive
machine # <
machine # * The requested URL returned error: 502
machine #   0   150    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
machine # * Closing connection
machine # curl: (22) The requested URL returned error: 502
```
