### PR TITLE
Filter SAWarning in pytest report

### DIFF
--- a/tests/flask_integration/database_gateway_impl/test_email_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_email_result.py
@@ -8,6 +8,7 @@ from .utility import Utility
 
 
 class CreateEmailAddressTests(FlaskTestCase):
+    @pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
     def test_cannot_create_same_email_address_twice(self) -> None:
         address = "test@test.test"
         self.database_gateway.create_email_address(address=address, confirmed_on=None)
@@ -16,6 +17,7 @@ class CreateEmailAddressTests(FlaskTestCase):
                 address=address, confirmed_on=datetime.min
             )
 
+    @pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
     def test_cannot_create_similar_email_address_case_insensitive(self) -> None:
         address = "test@test.test"
         self.database_gateway.create_email_address(address=address, confirmed_on=None)

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
+import pytest
 from parameterized import parameterized
 from sqlalchemy.exc import IntegrityError
 
@@ -173,6 +174,7 @@ class CreateMemberTests(MemberResultTests):
         assert account_credentials
         self.create_member_from_credentials(credentials=account_credentials.id)
 
+    @pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
     def test_cannot_create_member_with_same_email_twice(self) -> None:
         email = "test@test.test"
         self.create_member(email_address=email)


### PR DESCRIPTION
When running our tests via pytest, three tests in our testsuite show "sqlalchemy.exc.SAWarning"  in the test report. This is because we are trying to create a second email address with the same primary key. This commit filters the warnings.

The filtering happens on testcase level. The alternative, filtering via an entry in the `pyproject.toml` file was rejected as being considered too general.