### PR TITLE
Filter deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,8 @@ module = [
     "sqlalchemy.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:.*jsonschema.RefResolver is deprecated.*:DeprecationWarning:flask_restx\\.api",
+]


### PR DESCRIPTION
The library flask-restx is raising a warning, that jsonschema.RefResolver is deprecated. It is shown in our pytest reports. We are filtering this message out, because the maintainers are working on it.