### PR TITLE
Fix bug in auto migration

### DIFF
--- a/arbeitszeit_flask/migrations/auto_migrate.py
+++ b/arbeitszeit_flask/migrations/auto_migrate.py
@@ -1,0 +1,13 @@
+from flask import Config
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import Engine
+
+def migrate(flask_config: Config, engine: Engine) -> None:
+    # For details see:
+    # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-connection-across-one-or-more-programmatic-migration-commands
+    alembic_cfg = AlembicConfig(flask_config["ALEMBIC_CONFIGURATION_FILE"])
+    with engine.begin() as connection:
+        alembic_cfg.attributes["connection"] = connection
+        alembic_command.stamp(alembic_cfg, "head")
+        alembic_command.upgrade(alembic_cfg, "head")

--- a/arbeitszeit_flask/migrations/env.py
+++ b/arbeitszeit_flask/migrations/env.py
@@ -4,9 +4,6 @@ from arbeitszeit_flask import load_configuration
 
 from arbeitszeit_flask.database.db import Database
 from flask import Flask
-from collections.abc import Iterable
-from alembic.environment import MigrationContext
-from alembic.operations import MigrationScript
 
 from alembic import context
 
@@ -14,15 +11,11 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
+# 'autogenerate' support
 from arbeitszeit_flask.database.models import Base
 target_metadata = Base.metadata
 
@@ -33,28 +26,7 @@ target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url,
-        target_metadata=target_metadata,
-        literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
-    )
-
-    with context.begin_transaction():
-        context.run_migrations()
-
+    raise NotImplementedError()
 
 def get_db_uri() -> str:
     tmp_flask_app = Flask(__name__)
@@ -62,39 +34,25 @@ def get_db_uri() -> str:
     db_uri = tmp_flask_app.config["SQLALCHEMY_DATABASE_URI"]
     return db_uri
 
-
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+    connectable = config.attributes.get('connection', None)
+    if connectable is None:
+        Database().configure(get_db_uri())   
+        connectable = Database().engine
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+            )
 
-    """
-    # this callback is used to prevent an auto-migration from being generated
-    # when there are no changes to the schema
-    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
-    def process_revision_directives(
-        context: MigrationContext,
-        revision: str | Iterable[str | None] | Iterable[str],
-        directives: list[MigrationScript],
-    ):
-        assert config.cmd_opts is not None
-        if getattr(config.cmd_opts, 'autogenerate', False):
-            script = directives[0]
-            assert script.upgrade_ops is not None
-            if script.upgrade_ops.is_empty():
-                directives[:] = []
-
-    Database().configure(get_db_uri())   
-    connectable = Database().engine
-
-    with connectable.connect() as connection:
+            with context.begin_transaction():
+                context.run_migrations()
+    else:
         context.configure(
-            connection=connection,
+            connection=connectable,
             target_metadata=target_metadata,
-            process_revision_directives=process_revision_directives
         )
-
         with context.begin_transaction():
             context.run_migrations()
 

--- a/tests/flask_integration/dependency_injection.py
+++ b/tests/flask_integration/dependency_injection.py
@@ -38,6 +38,7 @@ class FlaskConfiguration(dict):
                 "MAIL_PLUGIN_CLASS": MockEmailService.__name__,
                 "LANGUAGES": {"en": "English", "de": "Deutsch", "es": "Español"},
                 "ARBEITSZEIT_PASSWORD_HASHER": "tests.password_hasher:PasswordHasherImpl",
+                "AUTO_MIGRATE": False,
             }
         )
 

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -72,14 +72,16 @@ class FlaskTestCase(TestCase):
         self.app = self.injector.get(Flask)
         self.app_context = self.app.app_context()
         self.app_context.push()
-        self.db = Database()  # Database gets configured in create_app
-        Base.metadata.drop_all(self.db.engine)
-        Base.metadata.create_all(self.db.engine)
+        # At this point, the database has already been configured
+        # and its tables have been created via the `create_app` function in
+        # `arbeitszeit_flask/__init__.py`
+        self.db = Database()
 
     def tearDown(self) -> None:
         self._lazy_property_cache = dict()
         self.db.session.remove()
         self.app_context.pop()
+        Base.metadata.drop_all(self.db.engine)
         super().tearDown()
 
     def get_injection_modules(self) -> List[Module]:

--- a/tests/flask_integration/test_db_migrations.py
+++ b/tests/flask_integration/test_db_migrations.py
@@ -1,0 +1,39 @@
+from arbeitszeit.injector import Binder, CallableProvider, Module
+from tests.flask_integration.flask import FlaskTestCase
+
+from .dependency_injection import FlaskConfiguration
+
+
+class AutoMigrationsTestCase(FlaskTestCase):
+    @property
+    def auto_migrate_setting(self) -> bool:
+        raise NotImplementedError()
+
+    def get_injection_modules(self) -> list[Module]:
+        auto_migrate_setting = self.auto_migrate_setting
+
+        class _Module(Module):
+            def configure(self, binder: Binder) -> None:
+                super().configure(binder)
+                binder[FlaskConfiguration] = CallableProvider(
+                    _Module.provide_flask_configuration
+                )
+
+            @staticmethod
+            def provide_flask_configuration() -> FlaskConfiguration:
+                configuration = FlaskConfiguration.default()
+                configuration["AUTO_MIGRATE"] = auto_migrate_setting
+                return configuration
+
+        modules = super().get_injection_modules()
+        modules.append(_Module())
+        return modules
+
+
+class AutoMigrationTests(AutoMigrationsTestCase):
+    @property
+    def auto_migrate_setting(self) -> bool:
+        return True
+
+    def test_that_app_starts_successfully_with_auto_migrate(self) -> None:
+        assert self.app


### PR DESCRIPTION
**Add test for startup w/ auto_migrate = True**

**Fix bug in auto migration** 

Before this commit, the AUTO_MIGRATE config option did not work as expected for the test or the production db, because our migration tool alembic would migrate always the dev db. Now the correct db engine is passed to the migration script in `arbeitszeit_flask.migrations.env.py`, to make sure that the correct db is auto migrated.

Moreover, when auto migrating, alembic now "stamps" databases that were not initialized with alembic, to enable the migration on that db.