### PR TITLE
Migrations - Do not stamp db

### DIFF
--- a/arbeitszeit_flask/database/db.py
+++ b/arbeitszeit_flask/database/db.py
@@ -45,11 +45,3 @@ class Database:
 
 class Base(DeclarativeBase):
     pass
-
-
-def init_db(uri: str) -> None:
-    from arbeitszeit_flask.database import models  # noqa: F401
-
-    Database().configure(uri=uri)
-    engine = Database().engine
-    Base.metadata.create_all(bind=engine)

--- a/arbeitszeit_flask/migrations/auto_migrate.py
+++ b/arbeitszeit_flask/migrations/auto_migrate.py
@@ -9,5 +9,5 @@ def migrate(flask_config: Config, engine: Engine) -> None:
     alembic_cfg = AlembicConfig(flask_config["ALEMBIC_CONFIGURATION_FILE"])
     with engine.begin() as connection:
         alembic_cfg.attributes["connection"] = connection
-        alembic_command.stamp(alembic_cfg, "head")
+        alembic_command.ensure_version(alembic_cfg)
         alembic_command.upgrade(alembic_cfg, "head")

--- a/arbeitszeit_flask/migrations/versions/15d33dfe8ec7_.py
+++ b/arbeitszeit_flask/migrations/versions/15d33dfe8ec7_.py
@@ -8,7 +8,6 @@ Create Date: 2023-02-15 13:04:28.046515
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import orm
 from uuid import UUID
 
@@ -67,7 +66,7 @@ def downgrade():
     op.drop_table('labour_certificates_payout')
 
 
-Base = declarative_base()
+Base = orm.declarative_base()
 
 
 class Company(Base):

--- a/arbeitszeit_flask/migrations/versions/3b00c719fe52_remove_obsolete_field_plan_active_days.py
+++ b/arbeitszeit_flask/migrations/versions/3b00c719fe52_remove_obsolete_field_plan_active_days.py
@@ -7,7 +7,6 @@ Create Date: 2023-02-12 14:50:13.203584
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import orm
 from datetime import datetime
 
@@ -28,7 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    Base = declarative_base()
+    Base = orm.declarative_base()
     class Plan(Base):
         __tablename__ = "plan"
 

--- a/arbeitszeit_flask/migrations/versions/8245d6c57ca5_create_registered_hours_worked_table.py
+++ b/arbeitszeit_flask/migrations/versions/8245d6c57ca5_create_registered_hours_worked_table.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
 
 revision = "8245d6c57ca5"
 down_revision = "51b2f780aba4"
@@ -47,7 +46,7 @@ def upgrade():
         sa.PrimaryKeyConstraint("id"),
     )
 
-    Base = declarative_base()
+    Base = orm.declarative_base()
 
     class RegisteredHoursWorked(Base):
         __tablename__ = "registered_hours_worked"

--- a/arbeitszeit_flask/migrations/versions/c917f02f0e95_introduce_coordination_tenure_table.py
+++ b/arbeitszeit_flask/migrations/versions/c917f02f0e95_introduce_coordination_tenure_table.py
@@ -8,7 +8,6 @@ Create Date: 2023-08-13 12:36:09.404241
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
 from uuid import uuid4
 
 
@@ -21,7 +20,7 @@ depends_on = None
 
 def upgrade():
 
-    Base = declarative_base()
+    Base = orm.declarative_base()
 
     class Cooperation(Base):
         __tablename__ = "cooperation"


### PR DESCRIPTION
**Do not stamp db to "head"** 

Do not stamp databases with alembic version of “head” when auto migrating. This leads to skipping of all missing migrations in the respective database, because Alembic sees the database as already up-to-date and does not upgrade.

Instead only create the alembic version table if it does not exist. This ensures that databases without alembic version table can get migrated as well.

**Refactor database initialization and migration logic** 

Modify database setup to support either auto-migration OR direct table creation, in `create_app` function. Removing the separate init_db function.

Before this refactoring, `nix flake check` would fail in `test_that_app_starts_successfully_with_auto_migrate`, beause alembic tries to create tables when they have already been created by SQLAlchemy.

**Change deprecated import statement** 

The `declarative_base()` function is now available as sqlalchemy.orm.declarative_base()