### PR TITLE
Change info_tooltip button type

### DIFF
--- a/arbeitszeit_flask/templates/macros/tooltips.html
+++ b/arbeitszeit_flask/templates/macros/tooltips.html
@@ -1,7 +1,7 @@
 {% macro info_tooltip(id, text) %}
 <div class="dropdown is-right">
     <button
-        class="dropdown-trigger"
+        type="button"
         aria-haspopup="true"
         aria-controls="{{ id }}"
         aria-describedby="{{ id }}"


### PR DESCRIPTION
Changed it to type="button" to prevent submitting the form when clicked.

fixes #1185