### PR TITLE
Create TransferType enum

### DIFF
--- a/arbeitszeit/transfers/transfer_type.py
+++ b/arbeitszeit/transfers/transfer_type.py
@@ -1,0 +1,17 @@
+from enum import Enum, auto
+
+
+class TransferType(Enum):
+    credit_p = auto()
+    credit_r = auto()
+    credit_a = auto()
+    credit_public_p = auto()
+    credit_public_r = auto()
+    credit_public_a = auto()
+    private_consumption = auto()
+    productive_consumption_p = auto()
+    productive_consumption_r = auto()
+    compensation_for_coop = auto()
+    compensation_for_company = auto()
+    work_certificates = auto()
+    taxes = auto()


### PR DESCRIPTION
This class enumerates all possible transfer types. The names of the indiviual types are intended to be as short and comprehensible as possible. E.g., I chose the name `taxes` over more correct, but less  comprehensible alternatives.

The possible transfer types are deducted from the discussion in "RFC - Design of accounts and transactions" #1175

fixes #1198