### PR TITLE
Testing public sector fund

### DIFF
--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -277,7 +277,7 @@ class PlanGenerator:
                 planner=planner,
             )
         )
-        assert not response.is_rejected
+        assert not response.is_rejected, f"Could not create draft: {response}"
         assert response.draft_id
         return response.draft_id
 

--- a/tests/economic_scenarios.py
+++ b/tests/economic_scenarios.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from arbeitszeit import records
+from arbeitszeit.payout_factor import PayoutFactorService
+from arbeitszeit.repositories import DatabaseGateway
+from tests.data_generators import PlanGenerator
+from tests.datetime_service import FakeDatetimeService
+
+
+@dataclass
+class EconomicScenarios:
+    plan_generator: PlanGenerator
+    payout_factor_service: PayoutFactorService
+    datetime_service: FakeDatetimeService
+    database_gateway: DatabaseGateway
+
+    def setup_environment_with_fic(self, target_fic: Decimal) -> None:
+        """Sets up testing environment with plans that result in a specific FIC value
+
+        Parameters:
+            target_fic: The payout factor (FIC) to achieve. Must be between 0 and 1.
+
+        We expect that there are no plans in the database and a FIC of 1 before this function is called.
+        """
+        assert (
+            not self.database_gateway.get_plans()
+        ), "There should be no plans in the database"
+        assert self.payout_factor_service.calculate_payout_factor(
+            self.datetime_service.now()
+        ) == Decimal(1), "Payout factor is not 1"
+        if target_fic < 0 or target_fic > 1:
+            raise ValueError("FIC must be between 0 and 1")
+        elif target_fic == 1:
+            # For FIC = 1, we just need a productive plan with no public plans
+            self.plan_generator.create_plan(
+                is_public_service=False,
+                costs=records.ProductionCosts(
+                    labour_cost=Decimal(1000),
+                    means_cost=Decimal(0),
+                    resource_cost=Decimal(0),
+                ),
+            )
+            return
+
+        # Choose reasonable default values for labor
+        productive_labor = Decimal(1000)
+        public_labor = Decimal(200)
+
+        # Calculate required sum of fixed means and resources in public plan
+        # Using the formula: fic = (L - (Po + Ro)) / (L + Lo)
+        # Rearranged to: (Po + Ro) = L - fic * (L + Lo)
+        required_public_means_and_resources = productive_labor - target_fic * (
+            productive_labor + public_labor
+        )
+
+        # Divide evenly between means and resources (for simplicity)
+        public_means = required_public_means_and_resources / 2
+        public_resources = required_public_means_and_resources / 2
+
+        # Create the productive plan
+        self.plan_generator.create_plan(
+            is_public_service=False,
+            costs=records.ProductionCosts(
+                labour_cost=productive_labor,
+                means_cost=Decimal(0),  # Not relevant for FIC calculation
+                resource_cost=Decimal(0),  # Not relevant for FIC calculation
+            ),
+        )
+
+        # Create the public plan
+        self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=records.ProductionCosts(
+                labour_cost=public_labor,
+                means_cost=public_means,
+                resource_cost=public_resources,
+            ),
+        )
+        current_fic = self.payout_factor_service.calculate_payout_factor(
+            self.datetime_service.now()
+        )
+        assert round(current_fic, 4) == round(target_fic, 4)

--- a/tests/services/test_psf_balance_service.py
+++ b/tests/services/test_psf_balance_service.py
@@ -1,9 +1,14 @@
 from decimal import Decimal
+from uuid import UUID
 
 from parameterized import parameterized
 
 from arbeitszeit.psf_balance import PublicSectorFundService
 from arbeitszeit.records import ProductionCosts
+from arbeitszeit.use_cases.register_hours_worked import (
+    RegisterHoursWorked,
+    RegisterHoursWorkedRequest,
+)
 from tests.data_generators import TransactionGenerator
 from tests.use_cases.base_test_case import BaseTestCase
 
@@ -14,9 +19,79 @@ class PublicSectorFundServiceCalculationTests(BaseTestCase):
         self.service = self.injector.get(PublicSectorFundService)
         self.transaction_generator = self.injector.get(TransactionGenerator)
 
-    def test_psf_balance_is_zero_if_no_public_plans_and_no_transactions(self) -> None:
+    def test_balance_is_zero_if_no_plans_are_approved(self) -> None:
         psf_balance = self.service.calculate_psf_balance()
         self.assertEqual(psf_balance, 0)
+
+    def test_that_balance_is_zero_if_there_is_a_productive_plan_approval(self) -> None:
+        self.plan_generator.create_plan()
+        psf_balance = self.service.calculate_psf_balance()
+        assert psf_balance == Decimal(0)
+
+    def test_that_balance_is_negative_if_there_is_a_public_plan_approval(self) -> None:
+        self.plan_generator.create_plan(is_public_service=True)
+        psf_balance = self.service.calculate_psf_balance()
+        assert psf_balance < Decimal(0)
+
+    def test_that_after_registration_of_hours_worked_balance_is_zero_if_no_plan_approvals(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self._register_hours_worked(company, worker, Decimal(10))
+        psf_balance = self.service.calculate_psf_balance()
+        assert psf_balance == Decimal(0)
+
+    def test_that_after_registration_of_hours_worked_balance_is_zero_if_only_one_productive_plan_approval(
+        self,
+    ) -> None:
+        self.plan_generator.create_plan()
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self._register_hours_worked(company, worker, Decimal(10))
+        psf_balance = self.service.calculate_psf_balance()
+        assert psf_balance == Decimal(0)
+
+    @parameterized.expand(
+        [
+            (Decimal(0), Decimal(1)),
+            (Decimal(0.1), Decimal(9)),
+            (Decimal(0.5), Decimal(1)),
+            (Decimal(0.8), Decimal(0.5)),
+        ]
+    )
+    def test_that_balance_grows_if_payout_factor_is_smaller_than_one_and_worked_hours_are_registered(
+        self, payout_factor: Decimal, hours_worked: Decimal
+    ) -> None:
+        self.economic_scenarios.setup_environment_with_fic(payout_factor)
+        psf_balance_before = self.service.calculate_psf_balance()
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self._register_hours_worked(company, worker, hours_worked)
+        psf_balance_after = self.service.calculate_psf_balance()
+        assert psf_balance_after > psf_balance_before
+        assert round(psf_balance_after, 4) == round(
+            psf_balance_before + (hours_worked * (1 - payout_factor)), 4
+        )
+
+    @parameterized.expand(
+        [
+            (Decimal(10)),
+            (Decimal(100)),
+            (Decimal(1000)),
+        ]
+    )
+    def test_that_balance_stays_the_same_if_payout_factor_is_one_and_worked_hours_are_registered(
+        self, hours_worked: Decimal
+    ) -> None:
+        fic = Decimal(1)
+        self.economic_scenarios.setup_environment_with_fic(fic)
+        psf_balance_before = self.service.calculate_psf_balance()
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self._register_hours_worked(company, worker, hours_worked)
+        psf_balance_after = self.service.calculate_psf_balance()
+        assert psf_balance_after == psf_balance_before
 
     @parameterized.expand(
         [
@@ -27,7 +102,7 @@ class PublicSectorFundServiceCalculationTests(BaseTestCase):
             (Decimal(2), Decimal(-0.5), 10, Decimal(30)),
         ]
     )
-    def test_psf_balance_equals_sum_of_tx_amounts_sent_minus_tx_amounts_received_if_no_public_plans(
+    def test_balance_equals_sum_of_tx_amounts_sent_minus_tx_amounts_received_if_no_public_plans(
         self,
         hours_worked: Decimal,
         fic: Decimal,
@@ -52,7 +127,7 @@ class PublicSectorFundServiceCalculationTests(BaseTestCase):
         psf_balance = self.service.calculate_psf_balance()
         assert round(psf_balance, 1) == round(expected_psf_balance, 1)
 
-    def test_psf_balance_equals_sum_of_public_plans_r_plus_p_with_inverted_sign_if_no_transactions(
+    def test_balance_equals_sum_of_public_plans_r_plus_p_with_inverted_sign_if_no_transactions(
         self,
     ) -> None:
 
@@ -119,7 +194,7 @@ class PublicSectorFundServiceCalculationTests(BaseTestCase):
             ),
         ]
     )
-    def test_psf_balance_equals_difference_between_sum_of_tx_amounts_sent_minus_tx_amounts_received_and_sum_of_public_plans_r_plus_p(
+    def test_balance_equals_difference_between_sum_of_tx_amounts_sent_minus_tx_amounts_received_and_sum_of_public_plans_r_plus_p(
         self,
         hours_worked: Decimal,
         fic: Decimal,
@@ -166,3 +241,12 @@ class PublicSectorFundServiceCalculationTests(BaseTestCase):
 
         psf_balance = self.service.calculate_psf_balance()
         assert round(psf_balance, 1) == round(expected_psf_balance, 1)
+
+    def _register_hours_worked(
+        self, company_id: UUID, worker_id: UUID, hours_worked: Decimal
+    ) -> None:
+        use_case = self.injector.get(RegisterHoursWorked)
+        response = use_case(
+            RegisterHoursWorkedRequest(company_id, worker_id, hours_worked)
+        )
+        assert not response.is_rejected

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -13,6 +13,7 @@ from tests.data_generators import (
     PlanGenerator,
 )
 from tests.datetime_service import FakeDatetimeService
+from tests.economic_scenarios import EconomicScenarios
 from tests.email_notifications import EmailSenderTestImpl
 
 from .balance_checker import BalanceChecker
@@ -73,6 +74,7 @@ class BaseTestCase(TestCase):
         CoordinationTransferRequestGenerator
     )
     datetime_service = _lazy_property(FakeDatetimeService)
+    economic_scenarios = _lazy_property(EconomicScenarios)
     email_sender = _lazy_property(EmailSenderTestImpl)
     member_generator = _lazy_property(MemberGenerator)
     plan_generator = _lazy_property(PlanGenerator)


### PR DESCRIPTION
**Create new test module economic_scenarios.py** 

Currently we are using for test setup mainly the data generators from `tests.data_generators.py`. We have currently no place where we can define more complex test setups that build on top of these data generators. To this end a new `tests.economic_scenarios.py` module has been created.

For now, it provides one method, `setup_environment_with_fic`, which sets up a testing environment with plans that result in a specific FIC value.

**Add tests for public sector fund** 

This commit adds tests for the public sector fund. They are testing the psf balance using abstract business logic (use cases and services) instead of transactions directly, which is more stable and reliable. This abstract testing approach will be necessary when we model wages and taxes as transfers instead of transactions.