### PR TITLE
Add transfer type

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 from uuid import UUID
 
+from arbeitszeit.transfers.transfer_type import TransferType
+
 
 @dataclass
 class EmailAddress:
@@ -319,6 +321,7 @@ class Transfer:
     debit_account: UUID
     credit_account: UUID
     value: Decimal
+    type: TransferType
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -6,6 +6,7 @@ from typing import Generic, Iterable, Iterator, Optional, Protocol, Self, Tuple,
 from uuid import UUID
 
 from arbeitszeit import records
+from arbeitszeit.transfers.transfer_type import TransferType
 
 T = TypeVar("T", covariant=True)
 
@@ -606,6 +607,7 @@ class DatabaseGateway(Protocol):
         debit_account: UUID,
         credit_account: UUID,
         value: Decimal,
+        type: TransferType,
     ) -> records.Transfer: ...
 
     def get_transfers(self) -> TransferResult: ...

--- a/arbeitszeit/transfers/transfer_type.py
+++ b/arbeitszeit/transfers/transfer_type.py
@@ -1,17 +1,25 @@
-from enum import Enum, auto
+from enum import Enum
 
 
 class TransferType(Enum):
-    credit_p = auto()
-    credit_r = auto()
-    credit_a = auto()
-    credit_public_p = auto()
-    credit_public_r = auto()
-    credit_public_a = auto()
-    private_consumption = auto()
-    productive_consumption_p = auto()
-    productive_consumption_r = auto()
-    compensation_for_coop = auto()
-    compensation_for_company = auto()
-    work_certificates = auto()
-    taxes = auto()
+    """
+    Warning: These enum values map to database columns.
+    If you change them, you need to create a database migration.
+
+    See https://arbeitszeitapp.readthedocs.io/en/latest/concepts.html for
+    a documentation of the transfer types.
+    """
+
+    credit_p = "credit_p"
+    credit_r = "credit_r"
+    credit_a = "credit_a"
+    credit_public_p = "credit_public_p"
+    credit_public_r = "credit_public_r"
+    credit_public_a = "credit_public_a"
+    private_consumption = "private_consumption"
+    productive_consumption_p = "productive_consumption_p"
+    productive_consumption_r = "productive_consumption_r"
+    compensation_for_coop = "compensation_for_coop"
+    compensation_for_company = "compensation_for_company"
+    work_certificates = "work_certificates"
+    taxes = "taxes"

--- a/arbeitszeit/use_cases/register_hours_worked.py
+++ b/arbeitszeit/use_cases/register_hours_worked.py
@@ -8,6 +8,7 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.payout_factor import PayoutFactorService
 from arbeitszeit.records import SocialAccounting
 from arbeitszeit.repositories import DatabaseGateway
+from arbeitszeit.transfers.transfer_type import TransferType
 
 
 @dataclass
@@ -69,12 +70,14 @@ class RegisterHoursWorked:
             debit_account=company.work_account,
             credit_account=worker.account,
             value=use_case_request.hours_worked,
+            type=TransferType.work_certificates,
         )
         transfer_of_taxes = self.database_gateway.create_transfer(
             date=self.datetime_service.now(),
             debit_account=worker.account,
             credit_account=self.social_accounting.account_psf,
             value=use_case_request.hours_worked * (1 - fic),
+            type=TransferType.taxes,
         )
         self.database_gateway.create_registered_hours_worked(
             company=company.id,

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -10,6 +10,7 @@ from flask_login import UserMixin
 from sqlalchemy import Column, ForeignKey, String, Table
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit_flask.database.db import Base
 
 
@@ -201,6 +202,7 @@ class Transfer(Base):
     debit_account: Mapped[str] = mapped_column(ForeignKey("account.id"), index=True)
     credit_account: Mapped[str] = mapped_column(ForeignKey("account.id"), index=True)
     value: Mapped[Decimal]
+    type: Mapped[TransferType]
 
     def __repr__(self) -> str:
         fields = ", ".join(
@@ -210,6 +212,7 @@ class Transfer(Base):
                 f"debit_account={self.debit_account!r}",
                 f"credit_account={self.credit_account!r}",
                 f"value={self.value!r}",
+                f"type={self.type!r}",
             ]
         )
         return f"Transfer({fields})"

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql.expression import and_, delete, func, or_, update
 from sqlalchemy.sql.functions import concat
 
 from arbeitszeit import records
+from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit_flask.database import models
 from arbeitszeit_flask.database.db import Database
 from arbeitszeit_flask.database.models import (
@@ -2527,6 +2528,7 @@ class DatabaseGatewayImpl:
             debit_account=UUID(transfer.debit_account),
             credit_account=UUID(transfer.credit_account),
             value=Decimal(transfer.value),
+            type=transfer.type,
         )
 
     def create_transfer(
@@ -2535,6 +2537,7 @@ class DatabaseGatewayImpl:
         debit_account: UUID,
         credit_account: UUID,
         value: Decimal,
+        type: TransferType,
     ) -> records.Transfer:
         transfer = models.Transfer(
             id=str(uuid4()),
@@ -2542,6 +2545,7 @@ class DatabaseGatewayImpl:
             debit_account=str(debit_account),
             credit_account=str(credit_account),
             value=value,
+            type=type,
         )
         self.db.session.add(transfer)
         self.db.session.flush()

--- a/arbeitszeit_flask/migrations/versions/0f1f3b156d62_delete_old_database_types.py
+++ b/arbeitszeit_flask/migrations/versions/0f1f3b156d62_delete_old_database_types.py
@@ -19,7 +19,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    pass
+    op.execute("DROP TYPE IF EXISTS accounttypes")
+    op.execute("DROP TYPE IF EXISTS useraction")
 
 
 def downgrade() -> None:

--- a/arbeitszeit_flask/migrations/versions/0f1f3b156d62_delete_old_database_types.py
+++ b/arbeitszeit_flask/migrations/versions/0f1f3b156d62_delete_old_database_types.py
@@ -1,0 +1,26 @@
+"""Delete old database types
+
+Revision ID: 0f1f3b156d62
+Revises: d6f685a49a41
+Create Date: 2025-04-21 21:36:08.624847
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0f1f3b156d62'
+down_revision: Union[str, None] = 'd6f685a49a41'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/arbeitszeit_flask/migrations/versions/d6f685a49a41_add_column_transfer_type.py
+++ b/arbeitszeit_flask/migrations/versions/d6f685a49a41_add_column_transfer_type.py
@@ -1,0 +1,58 @@
+"""Add column transfer.type
+
+Revision ID: d6f685a49a41
+Revises: 93342c4aa821
+Create Date: 2025-04-21 13:18:41.083474
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd6f685a49a41'
+down_revision: Union[str, None] = '93342c4aa821'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create the enum type first
+    transfertype = postgresql.ENUM('credit_p', 'credit_r', 'credit_a', 'credit_public_p', 'credit_public_r', 'credit_public_a', 'private_consumption', 'productive_consumption_p', 'productive_consumption_r', 'compensation_for_coop', 'compensation_for_company', 'work_certificates', 'taxes', name='transfertype')
+    transfertype.create(op.get_bind())
+    
+    # Then add the column using the created enum type
+    op.add_column('transfer', sa.Column('type', sa.Enum('credit_p', 'credit_r', 'credit_a', 'credit_public_p', 'credit_public_r', 'credit_public_a', 'private_consumption', 'productive_consumption_p', 'productive_consumption_r', 'compensation_for_coop', 'compensation_for_company', 'work_certificates', 'taxes', name='transfertype'), nullable=False, server_default='credit_p'))
+    
+    # Update work certificate transfers
+    op.execute("""
+        UPDATE transfer
+        SET type = 'work_certificates'
+        WHERE id IN (
+            SELECT transfer_of_work_certificates
+            FROM registered_hours_worked
+        )
+    """)
+    
+    # Update tax transfers
+    op.execute("""
+        UPDATE transfer
+        SET type = 'taxes'
+        WHERE id IN (
+            SELECT transfer_of_taxes
+            FROM registered_hours_worked
+        )
+    """)
+    
+    # Remove the server default constraint now that we've set appropriate values
+    op.alter_column('transfer', 'type', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('transfer', 'type')
+    
+    # Drop the enum type as well
+    op.execute("DROP TYPE transfertype")

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 from arbeitszeit import records
 from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.repositories import DatabaseGateway
+from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit.use_cases import confirm_member, get_coop_summary
 from arbeitszeit.use_cases.accept_cooperation import (
     AcceptCooperation,
@@ -459,6 +460,7 @@ class TransferGenerator:
         debit_account: Optional[UUID] = None,
         credit_account: Optional[UUID] = None,
         value: Optional[Decimal] = None,
+        type: Optional[TransferType] = None,
     ) -> records.Transfer:
         if date is None:
             date = self.datetime_service.now()
@@ -468,11 +470,14 @@ class TransferGenerator:
             credit_account = self.database_gateway.create_account().id
         if value is None:
             value = Decimal(10)
+        if type is None:
+            type = TransferType.credit_p
         return self.database_gateway.create_transfer(
             date=date,
             debit_account=debit_account,
             credit_account=credit_account,
             value=value,
+            type=type,
         )
 
 

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -85,8 +85,6 @@ class FlaskTestCase(TestCase):
         self.app_context.pop()
         Base.metadata.drop_all(self.db.engine)
         self.db.session.execute(text("DROP TABLE IF EXISTS alembic_version"))
-        self.db.session.execute(text("DROP TYPE IF EXISTS accounttypes"))
-        self.db.session.execute(text("DROP TYPE IF EXISTS useraction"))
         self.db.session.commit()
         super().tearDown()
 

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -41,6 +41,7 @@ from arbeitszeit.records import (
     SocialAccounting,
     Transaction,
 )
+from arbeitszeit.transfers.transfer_type import TransferType
 
 Many = TypeVar("Many", bound=Hashable)
 One = TypeVar("One", bound=Hashable)
@@ -1973,6 +1974,7 @@ class MockDatabase:
         debit_account: UUID,
         credit_account: UUID,
         value: Decimal,
+        type: TransferType,
     ) -> records.Transfer:
         transfer = records.Transfer(
             id=uuid4(),
@@ -1980,6 +1982,7 @@ class MockDatabase:
             debit_account=debit_account,
             credit_account=credit_account,
             value=value,
+            type=type,
         )
         self.transfers[transfer.id] = transfer
         return transfer


### PR DESCRIPTION
- Add "type" field to transfer record 

  Transfers of labour time can only be of certain, limited types. It therefore makes sense to add an enum field "type" to the transfer record in order to distinguish between different kind of transfers without the need of elaborated database joins, etc. In the future, with arrival of undo-transfers or other new transfer types, it may be even impossible to distinguish between type of transfers without this new field.
  
  fixes #1219

- Remove old database types 

  This commit deletes the unused database types 'accounttypes' and 'useraction' from the db via a migration script.