### PR TITLE
Improve test isolation and performance of db and flask tests

### DIFF
--- a/arbeitszeit_flask/migrations/auto_migrate.py
+++ b/arbeitszeit_flask/migrations/auto_migrate.py
@@ -1,13 +1,12 @@
 from flask import Config
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
-from sqlalchemy import Engine
+from sqlalchemy import Engine, Connection
 
-def migrate(flask_config: Config, engine: Engine) -> None:
+def migrate(flask_config: Config, connection: Connection) -> None:
     # For details see:
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-connection-across-one-or-more-programmatic-migration-commands
     alembic_cfg = AlembicConfig(flask_config["ALEMBIC_CONFIGURATION_FILE"])
-    with engine.begin() as connection:
-        alembic_cfg.attributes["connection"] = connection
-        alembic_command.ensure_version(alembic_cfg)
-        alembic_command.upgrade(alembic_cfg, "head")
+    alembic_cfg.attributes["connection"] = connection
+    alembic_command.ensure_version(alembic_cfg)
+    alembic_command.upgrade(alembic_cfg, "head")

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -4,10 +4,10 @@ from unittest import TestCase
 from uuid import UUID
 
 from flask import Flask, current_app
-from sqlalchemy import text
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from arbeitszeit.injector import Module
-from arbeitszeit_flask.database.db import Base, Database
+from arbeitszeit_flask.database.db import Database
 from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
 from arbeitszeit_flask.token import FlaskTokenService
 from arbeitszeit_flask.url_index import GeneralUrlIndex
@@ -57,39 +57,48 @@ class _lazy_property(Generic[T]):
         raise Exception("This attribute is read-only")
 
 
-class LogInUser(Enum):
-    member = auto()
-    unconfirmed_member = auto()
-    company = auto()
-    unconfirmed_company = auto()
-    accountant = auto()
-
-
 @database_required
-class FlaskTestCase(TestCase):
+class DatabaseTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self._lazy_property_cache: dict[str, Any] = dict()
         self.injector = get_dependency_injector(self.get_injection_modules())
-        self.app = self.injector.get(Flask)
-        self.app_context = self.app.app_context()
-        self.app_context.push()
-        # At this point, the database has already been configured
-        # and its tables have been created via the `create_app` function in
-        # `arbeitszeit_flask/__init__.py`
-        self.db = Database()
+        self.db = self.injector.get(Database)
+        # Set up connection-level transaction for test isolation
+        self.connection = self.db.engine.connect()
+        self.transaction = self.connection.begin()
+        # Create test session
+        session_factory = sessionmaker(bind=self.connection)
+        self.test_session = scoped_session(session_factory)
+        # Use test session for all database operations
+        self.db._session = self.test_session
 
     def tearDown(self) -> None:
-        self._lazy_property_cache = dict()
-        self.db.session.remove()
-        self.app_context.pop()
-        Base.metadata.drop_all(self.db.engine)
-        self.db.session.execute(text("DROP TABLE IF EXISTS alembic_version"))
-        self.db.session.commit()
+        # Clean up database resources
+        if hasattr(self, "test_session"):
+            self.test_session.close()
+        if hasattr(self, "transaction"):
+            self.transaction.rollback()
+        if hasattr(self, "connection"):
+            self.connection.close()
         super().tearDown()
 
     def get_injection_modules(self) -> List[Module]:
         return []
+
+
+class FlaskTestCase(DatabaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._lazy_property_cache: dict[str, Any] = dict()
+        self.app = self.injector.get(Flask)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self) -> None:
+        self._lazy_property_cache = dict()
+        if hasattr(self, "app_context"):
+            self.app_context.pop()
+        super().tearDown()
 
     def email_service(self) -> MockEmailService:
         return current_app.extensions["arbeitszeit_email_plugin"]
@@ -113,6 +122,14 @@ class FlaskTestCase(TestCase):
     transaction_generator = _lazy_property(TransactionGenerator)
     transfer_generator = _lazy_property(TransferGenerator)
     url_index = _lazy_property(GeneralUrlIndex)
+
+
+class LogInUser(Enum):
+    member = auto()
+    unconfirmed_member = auto()
+    company = auto()
+    unconfirmed_company = auto()
+    accountant = auto()
 
 
 class ViewTestCase(FlaskTestCase):


### PR DESCRIPTION
This commit adds a new base test class, "DatabaseTestCase", which is intended to be used for database tests that do not need access to the flask app.

Furthermore the commit enhances the test isolation of integration tests by implementing a connection-level transaction in the new base test class, which gets rolled back in the `tearDown` method.

While all changes to the database in the tests are rolled back, the table creation, that happens in the create_app function, does not get rolled back. Keeping the tables between test runs allows for considerable better performance compared to before, where we dropped all tables after each test to achieve test isolation. On the authors machine, the `pytest` command now takes only 1:10 instead of 4:10 minutes.