### PR TITLE
Use session.flush() in benchmarks

### DIFF
--- a/arbeitszeit_benchmark/get_company_summary_benchmark.py
+++ b/arbeitszeit_benchmark/get_company_summary_benchmark.py
@@ -40,7 +40,7 @@ class GetCompanySummaryBenchmark:
                 )
         for _ in range(1000):
             self.plan_generator.create_plan(planner=self.company)
-        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/get_statistics.py
+++ b/arbeitszeit_benchmark/get_statistics.py
@@ -30,7 +30,7 @@ class GetStatisticsBenchmark:
             plan_generator.create_plan(
                 is_public_service=False, costs=self.random_production_costs()
             )
-        db.session.commit()
+        db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
+++ b/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
@@ -45,7 +45,7 @@ class QueryPlansSortedByActivationDateBenchmark:
             limit=None,
             offset=None,
         )
-        db.session.commit()
+        db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
+++ b/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
@@ -36,7 +36,7 @@ class ShowPrdAccountDetailsBenchmark:
         self.use_case = self.injector.get(
             show_prd_account_details.ShowPRDAccountDetailsUseCase
         )
-        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/show_r_account_details_benchmark.py
+++ b/arbeitszeit_benchmark/show_r_account_details_benchmark.py
@@ -35,7 +35,7 @@ class ShowRAccountDetailsBenchmark:
         self.use_case = self.injector.get(
             show_r_account_details.ShowRAccountDetailsUseCase
         )
-        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()


### PR DESCRIPTION
Instead of commiting the generated objects in the benchmark tests to the database with commit(), it is preferable to just use flush().