### PR TITLE
Explain accounts in dev docs

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -18,20 +18,50 @@ There are three user roles:
 Accounts  
 ---------
 
-The following accounts exist in the Arbeitszeitapp. See below for a list of allowed transfers between them.
+Seven different account types exist in our app. See :ref:`transfers-of-labor-time` for a list of allowed transfers between the accounts.
 
-* Each company has four accounts:
+**p**
 
-   * **p**: Fixed means of production
-   * **r**: Liquid means of production
-   * **a**: Labor ("Arbeit")
-   * **prd**: The total product, debited at the start of each plan cycle by the sum of the P, R, and A values, and then increased back toward zero, item by item, as the finished product gets consumed.
+*owner*: Company
 
-* **member**: Each member has an account for labor certificates.
+Each company has a "p" account ("Produktionsmittel" - means of production) where transfers related to the consumption or provision of "fixed means of production" are recorded. Fixed means of production are, for example, machines or buildings that wear out gradually and do not transfer their value to the product in one planning cycle all at once.
 
-* **psf**: The PSF account is used to track hours credited to and debited from the public sector. It is used to cover the costs of public plans.
+**r**
 
-* **cooperation**: Companies can form cooperations. Each cooperation has an account that tracks the differences between the consumed cooperative (averaged) prices and the actual costs (see below).
+*owner*: Company
+
+Each company has a "r" account ("Rohstoffe" - raw materials) where transfers related to the consumption or provision of "liquid means of production" are recorded. Liquid means of production are, for example, raw materials that transfer their value to the product in one planning cycle all at once.
+
+**a**
+
+*owner*: Company
+
+Each company has an "a" account ("Arbeit" - work), where inflows and outflows of work certificates are recorded.
+
+**prd**
+
+*owner*: Company
+
+Each company has a "prd" account ("Produkt" - product), where quantities of planned and delivered products are recorded. When a productive plan gets approved, the total planned costs are debited from this account. As the finished product gets consumed and work certificates are spent for it, the account balance increases back toward zero, item by item.
+
+**member**
+
+*owner*: Member
+
+Each member has a "member" account where inflows and outflows of work certificates are recorded. Work certificates are credited when a company registers work and debited when the member consumes a product. 
+
+**psf**
+
+*owner*: Social Accounting
+
+The "psf" account (Public Sector Fund) is used to track hours credited to and debited from the public sector. In the current implementation of the app, there is one Social Accounting instance with one psf account.
+
+**cooperation**
+
+*owner*: Cooperation
+
+Each cooperation has an account that tracks the differences between the consumed cooperative prices (averaged) and the actual costs (see :ref:`cooperations` for details).
+
 
 Plans
 -----
@@ -89,6 +119,8 @@ The FIC ranges from −∞ to 1, but in practice, it should never be negative. A
 * If FIC = 0, all labor is allocated to public plans, making all goods and services freely available. When workers register hours worked, they do not receive any work certificates, since their work goes entirely to freely available public-sector goods and services and thus cannot be exchanged for private consumption.
 * If FIC = 1, all labor is dedicated to productive plans, meaning nothing is freely available. Work certificates are issued in full without deductions.
 
+.. _cooperations:
+
 Cooperations 
 -------------
 
@@ -112,6 +144,8 @@ Note that the cooperative price is independent of the duration of the plans. Whe
 
 While this implementation may seem undemocratic at first glance, it must be noted that the Arbeitszeitapp only provides the technical front-end to diverse political processes that must happen in "real life". The app does not prescribe the political procedures that companies and communities choose to elect coordinators or to define cooperations. Because every company is able to create cooperations, companies that are unhappy with a certain coordination can easily form a new cooperation.
 
+
+.. _transfers-of-labor-time:
 
 Transfers of labor time
 -----------------------

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,53 +1,37 @@
 Important Concepts
 ==================
 
-The core principle of labor time accounting is to prevent the exploitation of others' work. 
-To achieve this, all transfers of working hours must be recorded, with clear rules on what is
-allowed. Based on the "Group of International Communists" (GIC), 
-this goal is achieved through bookkeeping of transfers between accounts. These accounts belong
-to different kind of users.
+The core principle of labor time accounting is to prevent the exploitation of others' work. To achieve this, all transfers of working hours must be recorded, with clear rules on what is allowed. Based on the "Group of International Communists" (GIC), this goal is achieved through bookkeeping of transfers between accounts. These accounts belong to different kind of users.
 
 User Roles
 ----------
 
 There are three user roles:
 
-* **Companies** can file plans for each product (or service) they
-  offer. A plan describes a product and defines how much working time
-  it will cost.
+* **Companies** can file plans for each product (or service) they offer. A plan describes a product and defines how much working time it will cost.
 
-* **Members** are workers in companies. They receive work certificates
-  for their worked hours. They can use them to consume products and 
-  services.
+* **Members** are workers in companies. They receive work certificates for their worked hours. They can use them to consume products and services.
 
-* **Accountants** are delegates of the cooperating network of
-  companies. They can approve company plans based on collectively
-  agreed criteria.
+* **Accountants** are delegates of the cooperating network of companies. They can approve company plans based on collectively agreed criteria.
 
 
 Accounts  
 ---------
 
-The following accounts exist in the Arbeitszeitapp. See below for a 
-list of allowed transfers between them.
+The following accounts exist in the Arbeitszeitapp. See below for a list of allowed transfers between them.
 
-- Each company has four accounts:
+* Each company has four accounts:
 
-  - **p**: Fixed means of production
-  - **r**: Liquid means of production
-  - **a**: Labor ("Arbeit")
-  - **prd**: The total product, debited at the start of each plan cycle by 
-    the sum of the P, R, and A values, and then increased back toward zero, 
-    item by item, as the finished product gets consumed.
+   * **p**: Fixed means of production
+   * **r**: Liquid means of production
+   * **a**: Labor ("Arbeit")
+   * **prd**: The total product, debited at the start of each plan cycle by the sum of the P, R, and A values, and then increased back toward zero, item by item, as the finished product gets consumed.
 
-- **member**: Each member has an account for labor certificates.
+* **member**: Each member has an account for labor certificates.
 
-- **psf**: The PSF account is used to track hours credited to and debited from
-  the public sector. It is used to cover the costs of public plans.
+* **psf**: The PSF account is used to track hours credited to and debited from the public sector. It is used to cover the costs of public plans.
 
-- **cooperation**: Companies can form cooperations. Each cooperation has an 
-  account that tracks the differences between the consumed cooperative (averaged) prices and the 
-  actual costs (see below).
+* **cooperation**: Companies can form cooperations. Each cooperation has an account that tracks the differences between the consumed cooperative (averaged) prices and the actual costs (see below).
 
 Plans
 -----
@@ -57,43 +41,36 @@ Companies define in plans, beside other things, the product to be produced, the 
 In our app, we distinguish between plan drafts and plans: A company creates a plan draft first. From the moment it files the plan with Social Accounting, it becomes a proper plan. 
 
 From now on, the plan has the following attributes:
-    - approved: bool 
-    - rejected: bool
-    - expired: bool
-    
+
+* approved: bool 
+* rejected: bool
+* expired: bool
+
 When a plan gets approved, a couple of transfers of labour time are happening: The planning company receives the planned hours credited to their P, R, and A accounts. If the plan is a productive plan, the planned hours are debited from the company's own PRD account, otherwise they are debited from Social Accounting's PSF account.
 
 We consider a plan "active" when it has been approved and not yet expired. The expiration date is approval date plus planned timeframe. After expiration, consumption cannot be registered anymore on that plan.
 
 See the "PlanDraft" and "Plan" records in ``arbeitszeit.records.py`` for details and actual implementation. To dive deeper, you could also have a look at the following use cases in ``arbeitszeit/use_cases``:
 
-- CreatePlanDraft
-- FilePlanWithAccounting
-- ApprovePlanUseCase
-- RejectPlanUseCase
+* CreatePlanDraft
+* FilePlanWithAccounting
+* ApprovePlanUseCase
+* RejectPlanUseCase
 
 Consumption
 -----------
 
-Productive consumption is the consumption of products by companies. Companies
-cannot consume products from public plans. The consuming company specifies
-whether it is acquiring fixed or liquid means of production. The cost of the
-product is then subtracted from either the P or R account of the consuming
-company and added to the PRD account of the producing company.
+Productive consumption is the consumption of products by companies. Companies cannot consume products from public plans. The consuming company specifies whether it is acquiring fixed or liquid means of production. The cost of the product is then subtracted from either the P or R account of the consuming company and added to the PRD account of the producing company.
 
-Private consumption is the consumption by members. The cost of the product is
-subtracted from the member's account and added to the PRD account of the
-producing company.
+Private consumption is the consumption by members. The cost of the product is subtracted from the member's account and added to the PRD account of the producing company.
 
 
 Labor Certificates and Factor of Individual Consumption (FIC)
 -------------------------------------------------------------
 
-Companies are registering the worked hours of its members. The respective members then
-receive the number of registered hours on their account. 
+Companies are registering the worked hours of its members. The respective members then receive the number of registered hours on their account. 
 
-At the same time, a certain amount of certificates are subtracted from the member's account 
-and added to the PSF account in order to cover the costs of public plans.
+At the same time, a certain amount of certificates are subtracted from the member's account and added to the PSF account in order to cover the costs of public plans.
 
 This amount is determined by the FIC. The FIC is calculated as follows:
 
@@ -107,67 +84,39 @@ where :math:`L` is the sum of all working hours in productive plans,
 :math:`P_o` is the sum of all fixed means of production in public plans, and
 :math:`R_o` is the sum of all liquid means of production in public plans. 
 
-The FIC ranges from −∞ to 1, but in practice, it should never be negative. 
-A negative FIC indicates that available labor is insufficient to cover the costs of public plans, 
-leading to the issuance of negative work certificates upon work registration.
+The FIC ranges from −∞ to 1, but in practice, it should never be negative. A negative FIC indicates that available labor is insufficient to cover the costs of public plans, leading to the issuance of negative work certificates upon work registration.
 
-- If FIC = 0, all labor is allocated to public plans, making all goods and services freely available. 
-  When workers register hours worked, they do not receive any work certificates, since their work 
-  goes entirely to freely available public-sector goods and services and thus cannot be 
-  exchanged for private consumption.
-- If FIC = 1, all labor is dedicated to productive plans, meaning nothing is freely available. 
-  Work certificates are issued in full without deductions.
+* If FIC = 0, all labor is allocated to public plans, making all goods and services freely available. When workers register hours worked, they do not receive any work certificates, since their work goes entirely to freely available public-sector goods and services and thus cannot be exchanged for private consumption.
+* If FIC = 1, all labor is dedicated to productive plans, meaning nothing is freely available. Work certificates are issued in full without deductions.
 
 Cooperations 
 -------------
 
-Companies that produce the same product can attach their plans to so-called 
-"cooperations". The purpose of a cooperation is to calculate the average 
-labor cost per product within a specific branch or industry. This 
-average labor cost, known as the cooperative price, is what customers will 
-pay for a product.
+Companies that produce the same product can attach their plans to so-called "cooperations". The purpose of a cooperation is to calculate the average labor cost per product within a specific branch or industry. This average labor cost, known as the cooperative price, is what customers will pay for a product.
 
 **Cooperative Price**
 
-The logic for calculating the cooperative price is implemented in the module 
-``arbeitszeit/price_calculator.py``. The cooperative price is determined 
-as the average cost per product of all plans in the cooperation. 
-The formula for the cooperative price is:
+The logic for calculating the cooperative price is implemented in the module ``arbeitszeit/price_calculator.py``. The cooperative price is determined as the average cost per product of all plans in the cooperation. The formula for the cooperative price is:
 
 .. math::
 
   \text{cooperative price} = \frac{1}{n} \sum_{i=1}^{n} \frac{\text{cost}_i}{\text{pieces}_i}
 
-where :math:`\text{cost}_i` is the total cost of the :math:`i`-th plan in the
-cooperation and :math:`\text{pieces}_i` is the total amount of produced pieces
-of the :math:`i`-th plan. The sum runs over all :math:`n` plans in the cooperation.
+where :math:`\text{cost}_i` is the total cost of the :math:`i`-th plan in the cooperation and :math:`\text{pieces}_i` is the total amount of produced pieces of the :math:`i`-th plan. The sum runs over all :math:`n` plans in the cooperation.
 
-Note that the cooperative price is independent of the duration of the plans.
-Whether one working hour was applied in one year or in one day, 
-the price will be one hour.
+Note that the cooperative price is independent of the duration of the plans. Whether one working hour was applied in one year or in one day, the price will be one hour.
 
 **Coordinators of Cooperations**
 
-"Empty" cooperations (without any plans attached) can be created by any 
-company. The company that creates a cooperation automatically becomes the 
-"coordinator" of that cooperation. A coordinator has several privileges and 
-duties: They can accept or deny incoming cooperation requests,
-remove plans from the cooperation, or transfer the coordination role to 
-another company. The history of past coordinator tenures is visible to all users.
+"Empty" cooperations (without any plans attached) can be created by any company. The company that creates a cooperation automatically becomes the "coordinator" of that cooperation. A coordinator has several privileges and duties: They can accept or deny incoming cooperation requests, remove plans from the cooperation, or transfer the coordination role to another company. The history of past coordinator tenures is visible to all users.
 
-While this implementation may seem undemocratic at first glance, it must be noted that the Arbeitszeitapp
-only provides the technical front-end to diverse political processes that must happen in "real life".
-The app does not prescribe the political procedures that companies and communities choose to 
-elect coordinators or to define cooperations. Because every company is able to create cooperations, 
-companies that are unhappy with a certain coordination can easily form a new cooperation.
+While this implementation may seem undemocratic at first glance, it must be noted that the Arbeitszeitapp only provides the technical front-end to diverse political processes that must happen in "real life". The app does not prescribe the political procedures that companies and communities choose to elect coordinators or to define cooperations. Because every company is able to create cooperations, companies that are unhappy with a certain coordination can easily form a new cooperation.
 
 
 Transfers of labor time
 -----------------------
 
-Transfers occur between two accounts, where the debit account is charged, 
-and the credit account is credited. The table below lists the allowed 
-transfers and their corresponding variable names in the code.
+Transfers occur between two accounts, where the debit account is charged, and the credit account is credited. The table below lists the allowed transfers and their corresponding variable names in the code.
 
 .. list-table::
    :widths: 30 20 20 60


### PR DESCRIPTION
- Standardize format in docs/concepts.rst 

  We experienced formatting issues that should be fixed by standardizing the format of concepts.rst. Mainly:

  - Do not break long lines
  - Use `*` instead of `-` for bullet points

- Improve section on Accounts in dev docs