### PR TITLE
Commit migrations when auto-migrating

### DIFF
--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -12,7 +12,7 @@ from arbeitszeit_flask.datetime import RealtimeDatetimeService
 from arbeitszeit_flask.extensions import csrf_protect, login_manager
 from arbeitszeit_flask.filters import icon_filter
 from arbeitszeit_flask.mail_service import load_email_plugin
-from arbeitszeit_flask.migrations.auto_migrate import migrate
+from arbeitszeit_flask.migrations.auto_migrate import auto_migrate
 from arbeitszeit_flask.profiling import (  # type: ignore
     initialize_flask_profiler,
     show_profile_info,
@@ -53,16 +53,14 @@ def create_app(
     db = Database()
     db.configure(uri=app.config["SQLALCHEMY_DATABASE_URI"])
 
+    # Choose between auto-migration or direct table creation
     if app.config["AUTO_MIGRATE"]:
         # Let Alembic handle table creation
-        migrate(
-            app.config, db.session.connection()
-        )  # we use the connection that can be rolled back in tests
+        auto_migrate(app.config, db)
     else:
-        # Create tables directly with SQLAlchemy if they do not exist
-        Base.metadata.create_all(
-            db.engine, checkfirst=True
-        )  # these table creations are not rolled back in tests for performance reasons
+        # Create tables directly with SQLAlchemy if they do not exist.
+        # These table creations are NOT rolled back in tests for performance reasons
+        Base.metadata.create_all(db.engine, checkfirst=True)
 
     # Where to redirect the user when he attempts to access a login_required
     load_email_plugin(app)

--- a/arbeitszeit_flask/migrations/auto_migrate.py
+++ b/arbeitszeit_flask/migrations/auto_migrate.py
@@ -1,12 +1,22 @@
 from flask import Config
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
-from sqlalchemy import Engine, Connection
 
-def migrate(flask_config: Config, connection: Connection) -> None:
+from arbeitszeit_flask.database.db import Database
+
+def auto_migrate(flask_config: Config, db: Database) -> None:
     # For details see:
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-connection-across-one-or-more-programmatic-migration-commands
     alembic_cfg = AlembicConfig(flask_config["ALEMBIC_CONFIGURATION_FILE"])
-    alembic_cfg.attributes["connection"] = connection
-    alembic_command.ensure_version(alembic_cfg)
-    alembic_command.upgrade(alembic_cfg, "head")
+
+    if flask_config.get("TESTING", False):
+        # Use the connection from the testing session
+        alembic_cfg.attributes["connection"] = db.session.connection()
+        alembic_command.ensure_version(alembic_cfg)
+        alembic_command.upgrade(alembic_cfg, "head")
+    else:
+        # Use a new connection, commiting it to the database
+        with db.engine.begin() as connection:
+            alembic_cfg.attributes["connection"] = connection
+            alembic_command.ensure_version(alembic_cfg)
+            alembic_command.upgrade(alembic_cfg, "head")


### PR DESCRIPTION
This commit ensures that migrations that are running in a production setting and AUTO_MIGRATE set to true, will be committed to the database.