### PR TITLE
Make transactions in db consumption tables non nullable

### DIFF
--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -238,7 +238,7 @@ class PrivateConsumption(Base):
 
     id: Mapped[str] = mapped_column(primary_key=True, default=generate_uuid)
     plan_id: Mapped[str] = mapped_column(ForeignKey("plan.id"))
-    transaction_id: Mapped[str | None] = mapped_column(ForeignKey("transaction.id"))
+    transaction_id: Mapped[str] = mapped_column(ForeignKey("transaction.id"))
     amount: Mapped[int]
 
 
@@ -247,7 +247,7 @@ class ProductiveConsumption(Base):
 
     id: Mapped[str] = mapped_column(primary_key=True, default=generate_uuid)
     plan_id: Mapped[str] = mapped_column(ForeignKey("plan.id"))
-    transaction_id: Mapped[str | None] = mapped_column(ForeignKey("transaction.id"))
+    transaction_id: Mapped[str] = mapped_column(ForeignKey("transaction.id"))
     amount: Mapped[int]
 
 

--- a/arbeitszeit_flask/migrations/versions/9ab8e18b4d0e_non_nullable_transactions_in_.py
+++ b/arbeitszeit_flask/migrations/versions/9ab8e18b4d0e_non_nullable_transactions_in_.py
@@ -1,0 +1,29 @@
+"""Non-nullable transactions in consumption tables
+
+Revision ID: 9ab8e18b4d0e
+Revises: 8a3b2c1d0e9f
+Create Date: 2025-05-18 02:07:45.768231
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '9ab8e18b4d0e'
+down_revision: Union[str, None] = '8a3b2c1d0e9f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('private_consumption', 'transaction_id',
+               nullable=False)
+    op.alter_column('productive_consumption', 'transaction_id',
+               nullable=False)
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
They where mistakenly nullable in the sqlalchemy table definitions. Also a migration has been added to ensure that these columns are non-nullable.