### PR TITLE
Change sphinx theme for dev docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,9 @@ sys.path.insert(0, os.path.abspath('..'))
 
 
 project = 'arbeitszeitapp'
-copyright = '2022, Gruppe Arbeitszeitapp'
+copyright = '2025, Gruppe Arbeitszeitapp'
 author = 'Gruppe Arbeitszeitapp'
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 extensions = [
     'sphinx.ext.autodoc',
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
+sphinx-rtd-theme
 
 -r ../requirements.txt

--- a/nix/pythonPackages/arbeitszeitapp.nix
+++ b/nix/pythonPackages/arbeitszeitapp.nix
@@ -20,6 +20,7 @@
   pytest,
   setuptools,
   sphinx,
+  sphinx-rtd-theme,
 }:
 buildPythonPackage {
   pname = "arbeitszeitapp";
@@ -33,6 +34,7 @@ buildPythonPackage {
   format = "pyproject";
   buildInputs = [
     sphinx
+    sphinx-rtd-theme
     parameterized
     Babel
     setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ parameterized
 psycopg2
 pytest
 sphinx
+sphinx-rtd-theme
 types-python-dateutil
 types-pytz
 types-setuptools


### PR DESCRIPTION
Currently the navigation on our dev docs [on readthedocs ](https://arbeitszeitapp.readthedocs.io/en/latest/introduction.html)are not very intuitive because of missing sidebar navigation.

This commit changes the theme to the sphinx-rtd-theme which should provide better integration for readthedocs.

The dev docs can be build locally via `make html && open build/html/index.html`