### PR TITLE
Show compensations in ShowPRDAccountDetailsUseCase

### DIFF
--- a/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
@@ -85,6 +85,11 @@ class ShowPRDAccountDetailsPresenter:
                 | TransferType.productive_consumption_r
             ):
                 return self.translator.gettext("Sale")
+            case (
+                TransferType.compensation_for_company
+                | TransferType.compensation_for_coop
+            ):
+                return self.translator.gettext("Cooperation compensation")
             case _:
                 raise ValueError(f"Unknown transfer type: {transfer.type}")
 
@@ -93,6 +98,7 @@ class ShowPRDAccountDetailsPresenter:
         peer: (
             show_prd_account_details.MemberPeer
             | show_prd_account_details.CompanyPeer
+            | show_prd_account_details.CooperationPeer
             | None
         ),
     ) -> str:
@@ -100,6 +106,8 @@ class ShowPRDAccountDetailsPresenter:
             return "user"
         elif isinstance(peer, show_prd_account_details.CompanyPeer):
             return "industry"
+        elif isinstance(peer, show_prd_account_details.CooperationPeer):
+            return "hands-helping"
         else:
             return ""
 
@@ -108,12 +116,15 @@ class ShowPRDAccountDetailsPresenter:
         peer: (
             show_prd_account_details.MemberPeer
             | show_prd_account_details.CompanyPeer
+            | show_prd_account_details.CooperationPeer
             | None
         ),
     ) -> str:
         if isinstance(peer, show_prd_account_details.MemberPeer):
             return self.translator.gettext("Anonymous worker")
         elif isinstance(peer, show_prd_account_details.CompanyPeer):
+            return peer.name
+        elif isinstance(peer, show_prd_account_details.CooperationPeer):
             return peer.name
         else:
             return ""

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -11,6 +11,7 @@ from tests.data_generators import (
     CoordinationTransferRequestGenerator,
     MemberGenerator,
     PlanGenerator,
+    TransferGenerator,
 )
 from tests.datetime_service import FakeDatetimeService
 from tests.economic_scenarios import EconomicScenarios
@@ -79,3 +80,4 @@ class BaseTestCase(TestCase):
     member_generator = _lazy_property(MemberGenerator)
     plan_generator = _lazy_property(PlanGenerator)
     price_checker = _lazy_property(PriceChecker)
+    transfer_generator = _lazy_property(TransferGenerator)


### PR DESCRIPTION
**Show compensations in ShowPRDAccountDetailsUseCase** 

In order to be able to test this implementation we must create transfers directly instead of making use of the PrivateConsumption use case, which would be preferable, because compensation transfers are not yet implemented in that use case.

Part of https://github.com/ida-arbeitszeit/arbeitszeitapp/issues/1229