### PR TITLE
Rely on use cases in data generator

### DIFF
--- a/tests/use_cases/test_end_cooperation.py
+++ b/tests/use_cases/test_end_cooperation.py
@@ -68,9 +68,7 @@ class TestEndCooperation(TestCase):
     def test_error_is_raised_when_requester_is_neither_coordinator_nor_planner(
         self,
     ) -> None:
-        plan = self.plan_generator.create_plan(
-            cooperation=self.coop_generator.create_cooperation()
-        )
+        plan = self.plan_generator.create_plan()
         cooperation = self.coop_generator.create_cooperation(plans=[plan])
 
         request = EndCooperationRequest(

--- a/tests/use_cases/test_list_coordinations_of_company.py
+++ b/tests/use_cases/test_list_coordinations_of_company.py
@@ -78,9 +78,7 @@ def test_only_cooperations_are_listed_where_requester_is_coordinator(
     expected_cooperation = cooperation_generator.create_cooperation(
         plans=[p1, p2], coordinator=company
     )
-    cooperation_generator.create_cooperation(
-        plans=[p1, p2], coordinator=company_generator.create_company_record()
-    )
+    cooperation_generator.create_cooperation()
     response = use_case(ListCoordinationsOfCompanyRequest(company.id))
     assert len(response.coordinations) == 1
     assert response.coordinations[0].id == expected_cooperation


### PR DESCRIPTION
Before this change the test data generator "CooperationGenerator" would rely on database operations to assign plans to a cooperation. Instead, it should rely on the use case path, because it prevents data generator user from unsupported operations like adding public plans to cooperations, adding plans to several cooperations, etc. The Generator has been changed. Moreover, the PlanGenerator has been refactored.