### PR TITLE
Update dev documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,6 @@
 .. |Generic badge| image:: https://github.com/arbeitszeit/arbeitszeitapp/actions/workflows/python-app.yml/badge.svg
    :target: https://github.com/arbeitszeit/arbeitszeitapp/actions/workflows/python-app.yml
 
-.. start-introduction-do-not-delete
 
 Introduction
 ============
@@ -25,8 +24,6 @@ products published, and work or consumption recorded.
 This application implements a theory (`"Arbeitszeitrechnung"
 <https://aaap.be/Pages/Transition-en-Fundamental-Principles-1930.html>`_)
 elaborated in the 1920s by members of a German working-class movement.
-
-.. end-introduction-do-not-delete
 
 Note on Stability and Breaking Changes
 ======================================

--- a/docs/how_to_contribute.rst
+++ b/docs/how_to_contribute.rst
@@ -1,38 +1,58 @@
 How to contribute
 =================
 
-There are several options for you to contribute to the project if you
-wish to do so.
+You can contribute in various ways, if you wish to do so:
 
 Translating the app
 -------------------
 
-The developers want people around the world to use the
-arbeitszeitapp. To achieve this, it's crucial to translate the app
-into as many languages as we can. Since we're a small team of software
-creators, we haven't had the resources to create a detailed guide on
-how to translate the app step by step. However, we invite you to reach
-out to us through the issue tracker on GitHub. The README file in this
-project provides technical details about our translation technology,
-but don't be concerned if you find it complex. We're here to assist
-you with the technical setup to the best of our ability. Feel free to
-ask for help!
+We want people around the world to use the arbeitszeitapp. To achieve this, it's crucial to translate the app into as many languages as we can. We are happy to help you with the translation process.
 
-Contributing to the source code
--------------------------------
+Contributing code
+------------------
 
-We appreciate contributions to the code! When you contribute to the
-project, it means you agree that your source code is distributed under
-our Free-and-Open-Source Software license. If you want to help with
-the project but don't know where to begin, check out the issue
-tracker. You can propose changes by `forking the repository
-<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_
-and creating a pull request on GitHub. This action initiates a review
-process by the arbeitszeitapp collective. Please be patient if we
-don't start reviewing your code immediately, as our resources are
-limited, and none of us is economically compensated for working on the
-app. If you're unsure about creating a pull request, don't worry –
-there's a `helpful guide
-<https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_
-in the GitHub documentation on how to do it. Feel free to refer to
-that!
+We appreciate contributions to the code! Before you start contributing, you'll need to set up your development environment. We recommend using Linux with Nix for development. The setup process is detailed in our :doc:`development_setup` guide, which covers:
+
+* Setting up PostgreSQL databases
+* Installing development dependencies
+* Configuring environment variables
+* Running the development server
+
+We maintain high code quality standards through:
+
+* Type hints and static type checking with ``mypy``
+* Code formatting with ``black`` and ``isort``
+* Linting with ``flake8``
+* Comprehensive test coverage
+
+You can propose changes by `forking the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_ and creating a pull request on GitHub.
+Before submitting changes, run ``./run-checks`` to ensure your code meets our standards.
+
+
+Working on Milestones
+-----------------------
+
+Milestones are our way of organizing larger work packages (>50h of work) that have been identified as important for the project. Unlike regular Issues or Pull Requests, milestones follow a formal approval process that includes an obligatory RFC (Request For Comments). This structured approach helps us plan better and ensures that all developers are aligned with the project's direction.
+
+Milestone Lifecycle
+~~~~~~~~~~~~~~~~~~~
+
+1. RFC Candidate
+    - An Issue on GitHub that has potential to become a Milestone
+    - Marked with the "rfc candidate" label
+    - Requires initial conceptual work and discussion
+    - View `current candidates <https://github.com/ida-arbeitszeit/arbeitszeitapp/issues?q=state%3Aopen%20label%3A%22rfc%20candidate%22>`_
+
+2. RFC (Request For Comments)
+    - A detailed proposal marked with the "RFC" label
+    - Must include a motivation for the change and a detailed implementation proposal
+    - Sent to the programmers mailing list for visibility
+    - Requires approval in an app group meeting
+    - View `current RFCs <https://github.com/ida-arbeitszeit/arbeitszeitapp/issues?q=is%3Aissue%20state%3Aopen%20label%3Arfc>`_
+
+3. Active Milestone
+    - Published on GitHub after RFC approval
+    - Ready for implementation
+    - View `all milestones <https://github.com/ida-arbeitszeit/arbeitszeitapp/milestones>`_
+
+Feel free to contribute to any of these stages.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,3 +1,31 @@
-.. include:: ../README.rst
-  :start-after: start-introduction-do-not-delete
-  :end-before: end-introduction-do-not-delete
+Introduction
+============
+
+About The App
+---------------
+
+Arbeitszeitapp is a plattform to exchange services and products on the
+basis of working time. It is designed as a Web app to be self-hosted by communities
+or organizations. A test instance is running on
+https://demo-app.arbeitszeitrechnung.org/.
+
+Companies usually calculate with labour time internally, but use
+money externally. This app extends labour time planning and
+calculation beyond company boundaries, enabling networks to
+exchanges products based on labour time.
+
+It offers planning tools for companies and communities, and work 
+time management for companies and workers. Plans can be approved, 
+products published, and work or consumption recorded.
+
+This application implements a theory (`"Arbeitszeitrechnung"
+<https://aaap.be/Pages/Transition-en-Fundamental-Principles-1930.html>`_)
+elaborated in the 1920s by members of a German working-class movement.
+
+
+The Arbeitszeitapp Collective
+-----------------------------
+
+We are a group of programmers closely associated with the `IDA association <arbeitszeit.noblogs.org>`_. To coordinate our work, we meet once a week for half an hour online. If needed, we can also meet in person at the IDA office in Berlin. Otherwise, we communicate via a mailing list and use the Github Issue tracker. 
+
+We are always looking for people who want to help us improve the app. If you are interested in contributing, please proceed to the :doc:`how_to_contribute` page for more information on how to get involved.


### PR DESCRIPTION
- Separate top-level README and "Introduction" section in dev docs to clarify their distinct purposes
- Add information about the arbeitszeitapp collective to the Introduction section
- Revise "How to contribute" section: explain the milestones workflow and streamline existing content