### PR TITLE
Provide dev server with data generation CLI

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,4 +1,4 @@
 ARBEITSZEITAPP_CONFIGURATION_PATH=${PWD}/arbeitszeit_flask/development_settings.py
-FLASK_APP=arbeitszeit_flask
+FLASK_APP=tests.development_server:main
 FLASK_DEBUG=1
 ARBEITSZEIT_APP_SERVER_NAME=127.0.0.1:5000

--- a/arbeitszeit_flask/commands.py
+++ b/arbeitszeit_flask/commands.py
@@ -14,6 +14,7 @@ from arbeitszeit_flask.dependency_injection import with_injection
 def invite_accountant(
     email_address: str, use_case: SendAccountantRegistrationTokenUseCase
 ) -> None:
+    """Invite an accountant by sending a registration token to the given email address."""
     with force_locale("de"):  # type: ignore
         use_case.send_accountant_registration_token(
             SendAccountantRegistrationTokenUseCase.Request(email=email_address)

--- a/docs/development_setup.rst
+++ b/docs/development_setup.rst
@@ -154,6 +154,14 @@ accountants from the terminal, using the following command:
 
 Again, an invitation mail with a confirmation link will be printed to ``stdout``.
 
+Developers can populate the development database automatically with test data. Run
+
+    .. code-block:: bash
+
+     flask generate --help
+
+to see the available options.
+
 
 Code Formatting and Analysis
 -----------------------------

--- a/tests/development_server.py
+++ b/tests/development_server.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+from arbeitszeit_flask import create_app
+from tests.flask_integration.dev_cli import generate
+
+
+def main() -> Flask:
+    app = create_app()
+    app.cli.add_command(generate)
+    return app

--- a/tests/flask_integration/dev_cli.py
+++ b/tests/flask_integration/dev_cli.py
@@ -1,0 +1,151 @@
+from decimal import Decimal
+from uuid import UUID
+
+import click
+from flask import current_app
+from flask.cli import AppGroup
+
+from arbeitszeit.records import ProductionCosts
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.dependency_injection import with_injection
+from tests.data_generators import (
+    CompanyGenerator,
+    ConsumptionGenerator,
+    CooperationGenerator,
+    PlanGenerator,
+)
+
+generate = AppGroup(
+    name="generate",
+    help="""
+    Generate test data for the development database. Internally, these commands make
+    use of the data generators, which in turn use the domain logic to create the data.
+
+    The ARBEITSZEITAPP_CONFIGURATION_PATH is used to derive the database connection
+    string and other configuration options.
+
+    Run `flask generate COMMAND --help` for more information on a specific command.
+    """,
+)
+
+
+@generate.command("plan")
+@click.option(
+    "--labour-cost",
+    "-l",
+    help="Labour cost.",
+    type=Decimal,
+)
+@commit_changes
+@with_injection()
+def generate_plan(labour_cost: Decimal | None, data_generator: PlanGenerator) -> None:
+    """Create a plan."""
+    if labour_cost:
+        costs = ProductionCosts(
+            labour_cost=labour_cost,
+            resource_cost=Decimal("0"),
+            means_cost=Decimal("0"),
+        )
+    else:
+        costs = None
+    plan_id = data_generator.create_plan(
+        costs=costs,
+    )
+    click.echo(f"Plan with ID {plan_id} created.")
+
+
+@generate.command("company")
+@commit_changes
+@with_injection()
+def generate_company(data_generator: CompanyGenerator) -> None:
+    """Create a company."""
+    company_id = data_generator.create_company()
+    click.echo(f"Company with ID {company_id} created.")
+
+
+@generate.command("private-consumption")
+@click.option(
+    "--plan",
+    "-p",
+    help="ID of plan to be consumed. If no plan is given, a plan will be created automatically.",
+    type=UUID,
+)
+@commit_changes
+@with_injection()
+def generate_private_consumption(
+    plan: UUID | None,
+    data_generator: ConsumptionGenerator,
+) -> None:
+    """
+    Create a private consumption.
+    """
+    current_app.config["ALLOWED_OVERDRAW_MEMBER"] = "unlimited"
+    data_generator.create_private_consumption(
+        plan=plan,
+    )
+    click.echo("Private consumption created.")
+
+
+@generate.command("productive-consumption-of-r")
+@click.option(
+    "--plan",
+    "-p",
+    help="ID of plan to be consumed. If no plan is given, a plan will be created automatically.",
+    type=UUID,
+)
+@commit_changes
+@with_injection()
+def generate_productive_consumption_of_r(
+    plan: UUID | None,
+    data_generator: ConsumptionGenerator,
+) -> None:
+    """
+    Create a productive consumption of raw materials.
+    """
+    data_generator.create_resource_consumption_by_company(
+        plan=plan,
+    )
+    click.echo("Productive consumption created.")
+
+
+@generate.command("productive-consumption-of-p")
+@click.option(
+    "--plan",
+    "-p",
+    help="ID of plan to be consumed. If no plan is given, a plan will be created automatically.",
+    type=UUID,
+)
+@commit_changes
+@with_injection()
+def generate_productive_consumption_of_p(
+    plan: UUID | None,
+    data_generator: ConsumptionGenerator,
+) -> None:
+    """
+    Create a productive consumption of fixed means.
+    """
+    data_generator.create_fixed_means_consumption(
+        plan=plan,
+    )
+    click.echo("Productive consumption created.")
+
+
+@generate.command("cooperation")
+@click.option(
+    "--plans",
+    "-p",
+    help="ID of plan to be included in the cooperation. Can be repeated to include multiple plans.",
+    multiple=True,
+    type=UUID,
+)
+@commit_changes
+@with_injection()
+def generate_cooperation(
+    plans: tuple[UUID],
+    data_generator: CooperationGenerator,
+) -> None:
+    """Create a cooperation."""
+    cooperation_id = data_generator.create_cooperation(
+        plans=list(plans) if plans else None
+    )
+    click.echo(f"Cooperation with ID {cooperation_id} created.")

--- a/tests/flask_integration/test_data_generation_cli.py
+++ b/tests/flask_integration/test_data_generation_cli.py
@@ -1,0 +1,50 @@
+from tests.flask_integration.dev_cli import generate
+from tests.flask_integration.flask import FlaskTestCase
+
+
+class DataGenerationCliTester(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.runner = self.app.test_cli_runner()
+
+    def test_generate_plan(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["plan", "--labour-cost", "100.00"],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_company(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["company"],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_private_consumption(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["private-consumption"],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_productive_consumption_of_r(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["productive-consumption-of-r"],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_productive_consumption_of_p(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["productive-consumption-of-p"],
+        )
+        assert result.exit_code == 0
+
+    def test_generate_cooperation(self) -> None:
+        result = self.runner.invoke(
+            generate,
+            ["cooperation"],
+        )
+        assert result.exit_code == 0


### PR DESCRIPTION
With this commit we enhance the flask dev server by registering a data generation CLI on it. This CLI uses internally the data generators from the `tests` folder, which in turn use the domain logic (use cases), to create records like companies or plans in the development database. By using the domain logic we make sure to only create consistent data.

Run `flask generate --help` for more information.

The data generation CLI code is located entirely in the tests folder and thus cannot get accidentally rolled out and used in the production environment.