### PR TITLE
Delete unnecessary icon attributes

### DIFF
--- a/arbeitszeit_flask/templates/user/company_accounts.html
+++ b/arbeitszeit_flask/templates/user/company_accounts.html
@@ -31,7 +31,7 @@
                         <td class="py-2"><a href="{{ view_model.url_to_account_p }}">{{
                                         gettext("Account p") }}</a>
                         </td>
-                        <td>{{ 'industry'|icon(attrs={ "width": "100%", "height": "100%" }) }}</td>
+                        <td>{{ 'industry'|icon }}</td>
                         <td class="is-italic">{{ gettext("Account for fixed means of production") }}
                         </td>
                         <td
@@ -42,7 +42,7 @@
                         <td class="py-2"><a href="{{ view_model.url_to_account_r }}">{{
                                         gettext("Account r") }}</a>
                         </td>
-                        <td>{{ "oil-can"|icon(attrs={ "width": "100%", "height": "100%" }) }}</td>
+                        <td>{{ "oil-can"|icon }}</td>
                         <td class="is-italic">{{ gettext("Account for liquid means of production")}}
                         </td>
                         <td
@@ -53,7 +53,7 @@
                         <td class="py-2"><a href="{{ view_model.url_to_account_a }}">{{
                                         gettext("Account a") }}</a>
                         </td>
-                        <td>{{ "users"|icon(attrs={ "width": "100%", "height": "100%" }) }}</td>
+                        <td>{{ "users"|icon }}</td>
                         <td class="is-italic">{{ gettext("Account for work certificates (wages)") }}
                         </td>
                         <td


### PR DESCRIPTION
Before this commit, icons in the company accounts view had unnecessary svg attributes that would render them too large in firefox browser.