### PR TITLE
Implement Transfers in Productive Consumptions

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -377,8 +377,9 @@ class PrivateConsumption:
 class ProductiveConsumption:
     id: UUID
     plan_id: UUID
-    transaction_id: UUID
     amount: int
+    transfer_of_productive_consumption: UUID
+    transfer_of_compensation: UUID | None
 
 
 AccountOwner = Union[Member, Company, SocialAccounting, Cooperation]

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -277,28 +277,28 @@ class ProductiveConsumptionResult(QueryResult[records.ProductiveConsumption], Pr
 
     def where_provider_is_company(self, company: UUID) -> Self: ...
 
-    def joined_with_transactions_and_plan(
+    def joined_with_transfer_and_plan(
         self,
     ) -> QueryResult[
-        Tuple[records.ProductiveConsumption, records.Transaction, records.Plan]
+        Tuple[records.ProductiveConsumption, records.Transfer, records.Plan]
     ]: ...
 
-    def joined_with_transaction_and_provider(
+    def joined_with_transfer_and_provider(
         self,
     ) -> QueryResult[
-        Tuple[records.ProductiveConsumption, records.Transaction, records.Company]
+        Tuple[records.ProductiveConsumption, records.Transfer, records.Company]
     ]: ...
 
-    def joined_with_transaction(
+    def joined_with_transfer(
         self,
-    ) -> QueryResult[Tuple[records.ProductiveConsumption, records.Transaction]]: ...
+    ) -> QueryResult[Tuple[records.ProductiveConsumption, records.Transfer]]: ...
 
-    def joined_with_transaction_and_plan_and_consumer(
+    def joined_with_transfer_and_plan_and_consumer(
         self,
     ) -> QueryResult[
         Tuple[
-            records.PrivateConsumption,
-            records.Transaction,
+            records.ProductiveConsumption,
+            records.Transfer,
             records.Plan,
             records.Company,
         ]
@@ -527,7 +527,11 @@ class DatabaseGateway(Protocol):
     def get_private_consumptions(self) -> PrivateConsumptionResult: ...
 
     def create_productive_consumption(
-        self, transaction: UUID, amount: int, plan: UUID
+        self,
+        plan: UUID,
+        amount: int,
+        transfer_of_productive_consumption: UUID,
+        transfer_of_compensation: UUID | None,
     ) -> records.ProductiveConsumption: ...
 
     def get_productive_consumptions(self) -> ProductiveConsumptionResult: ...

--- a/arbeitszeit/transfers/compensation.py
+++ b/arbeitszeit/transfers/compensation.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from arbeitszeit.datetime_service import DatetimeService
+from arbeitszeit.repositories import DatabaseGateway
+from arbeitszeit.transfers.transfer_type import TransferType
+
+
+@dataclass
+class CompensationTransferService:
+    """
+    For background on compensation transfers see project's developer documentation.
+    """
+
+    database_gateway: DatabaseGateway
+    datetime_service: DatetimeService
+
+    def create_compensation_transfer(
+        self,
+        coop_price_per_unit: Decimal,
+        plan_price_per_unit: Decimal,
+        consumed_amount: int,
+        planner_product_account: UUID,
+        cooperation_account: UUID,
+    ) -> UUID | None:
+        difference = coop_price_per_unit - plan_price_per_unit
+        if not difference:
+            return None
+        elif difference < Decimal(0):
+            """Plan is underproductive."""
+            return self._compensate_company(
+                consumed_amount=consumed_amount,
+                difference=abs(difference),
+                cooperation_account=cooperation_account,
+                planner_product_account=planner_product_account,
+            )
+        else:
+            """Plan is overproductive."""
+            return self._compensate_cooperation(
+                consumed_amount=consumed_amount,
+                difference=abs(difference),
+                cooperation_account=cooperation_account,
+                planner_product_account=planner_product_account,
+            )
+
+    def _compensate_cooperation(
+        self,
+        consumed_amount: int,
+        difference: Decimal,
+        cooperation_account: UUID,
+        planner_product_account: UUID,
+    ) -> UUID:
+        transfer = self.database_gateway.create_transfer(
+            date=self.datetime_service.now(),
+            debit_account=planner_product_account,
+            credit_account=cooperation_account,
+            value=difference * consumed_amount,
+            type=TransferType.compensation_for_coop,
+        )
+        return transfer.id
+
+    def _compensate_company(
+        self,
+        consumed_amount: int,
+        difference: Decimal,
+        cooperation_account: UUID,
+        planner_product_account: UUID,
+    ) -> UUID:
+        transfer = self.database_gateway.create_transfer(
+            date=self.datetime_service.now(),
+            debit_account=cooperation_account,
+            credit_account=planner_product_account,
+            value=difference * consumed_amount,
+            type=TransferType.compensation_for_company,
+        )
+        return transfer.id

--- a/arbeitszeit/use_cases/query_company_consumptions.py
+++ b/arbeitszeit/use_cases/query_company_consumptions.py
@@ -9,7 +9,7 @@ from arbeitszeit.records import (
     ConsumptionType,
     Plan,
     ProductiveConsumption,
-    Transaction,
+    Transfer,
 )
 from arbeitszeit.repositories import DatabaseGateway
 
@@ -39,30 +39,30 @@ class QueryCompanyConsumptions:
         assert company_record
         return (
             self._consumption_to_response_model(
-                consumption, transaction, plan, company_record
+                consumption, transfer, plan, company_record
             )
-            for consumption, transaction, plan in consumptions.ordered_by_creation_date(
+            for consumption, transfer, plan in consumptions.ordered_by_creation_date(
                 ascending=False
-            ).joined_with_transactions_and_plan()
+            ).joined_with_transfer_and_plan()
         )
 
     def _consumption_to_response_model(
         self,
         consumption: ProductiveConsumption,
-        transaction: Transaction,
+        transfer: Transfer,
         plan: Plan,
         company: Company,
     ) -> ConsumptionQueryResponse:
-        if transaction.sending_account == company.raw_material_account:
+        if transfer.debit_account == company.raw_material_account:
             consumption_type = ConsumptionType.raw_materials
         else:
             consumption_type = ConsumptionType.means_of_prod
         return ConsumptionQueryResponse(
-            consumption_date=transaction.date,
+            consumption_date=transfer.date,
             plan_id=plan.id,
             product_name=plan.prd_name,
             product_description=plan.description,
             consumption_type=consumption_type,
-            price_per_unit=transaction.amount_sent / consumption.amount,
+            price_per_unit=transfer.value / consumption.amount,
             amount=consumption.amount,
         )

--- a/arbeitszeit/use_cases/review_registered_consumptions.py
+++ b/arbeitszeit/use_cases/review_registered_consumptions.py
@@ -65,18 +65,18 @@ class ReviewRegisteredConsumptionsUseCase:
         productive_consumptions_result = (
             self.database.get_productive_consumptions()
             .where_provider_is_company(request.providing_company)
-            .joined_with_transaction_and_plan_and_consumer()
+            .joined_with_transfer_and_plan_and_consumer()
         )
-        for _, transaction, plan, company in productive_consumptions_result:
+        for _, transfer, plan, company in productive_consumptions_result:
             productive_consumptions.append(
                 RegisteredConsumption(
-                    date=transaction.date,
+                    date=transfer.date,
                     is_private_consumption=False,
                     consumer_name=company.name,
                     consumer_id=company.id,
                     product_name=plan.prd_name,
                     plan_id=plan.id,
-                    labour_hours_consumed=transaction.amount_sent,
+                    labour_hours_consumed=transfer.value,
                 )
             )
         return productive_consumptions

--- a/arbeitszeit/use_cases/show_p_account_details.py
+++ b/arbeitszeit/use_cases/show_p_account_details.py
@@ -81,15 +81,15 @@ class ShowPAccountDetailsUseCase:
     def _add_consumption_transfers(
         self, company: Company, transfers: list[TransferInfo]
     ) -> None:
-        transactions = self.database.get_transactions().where_account_is_sender(
+        consumption_transfers = self.database.get_transfers().where_account_is_debtor(
             company.means_account
         )
-        for transaction in transactions:
+        for transfer in consumption_transfers:
             transfers.append(
                 self.TransferInfo(
                     type=TransferType.productive_consumption_p,
-                    date=transaction.date,
-                    volume=-transaction.amount_sent,
+                    date=transfer.date,
+                    volume=-transfer.value,  # negative because the company is the debtor
                 )
             )
 

--- a/arbeitszeit/use_cases/show_r_account_details.py
+++ b/arbeitszeit/use_cases/show_r_account_details.py
@@ -85,15 +85,15 @@ class ShowRAccountDetailsUseCase:
     def _add_consumption_transfers(
         self, company: Company, transfers: list[TransferInfo]
     ) -> None:
-        transactions = self.database.get_transactions().where_account_is_sender(
+        consumption_transfers = self.database.get_transfers().where_account_is_debtor(
             company.raw_material_account
         )
-        for transaction in transactions:
+        for transfer in consumption_transfers:
             transfers.append(
                 TransferInfo(
                     type=TransferType.productive_consumption_r,
-                    date=transaction.date,
-                    volume=-transaction.amount_sent,
+                    date=transfer.date,
+                    volume=-transfer.value,  # negative because the company is the debtor
                 )
             )
 

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -252,7 +252,12 @@ class ProductiveConsumption(Base):
 
     id: Mapped[str] = mapped_column(primary_key=True, default=generate_uuid)
     plan_id: Mapped[str] = mapped_column(ForeignKey("plan.id"))
-    transaction_id: Mapped[str] = mapped_column(ForeignKey("transaction.id"))
+    transfer_of_productive_consumption: Mapped[str] = mapped_column(
+        ForeignKey("transfer.id")
+    )
+    transfer_of_compensation: Mapped[str | None] = mapped_column(
+        ForeignKey("transfer.id")
+    )
     amount: Mapped[int]
 
 

--- a/arbeitszeit_flask/migrations/versions/8b51e4ca0073_transfers_in_productive_consumption.py
+++ b/arbeitszeit_flask/migrations/versions/8b51e4ca0073_transfers_in_productive_consumption.py
@@ -1,0 +1,211 @@
+"""transfers in productive consumption
+
+Revision ID: 8b51e4ca0073
+Revises: 3c8b03a2c899
+Create Date: 2025-06-02 13:21:31.013768
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '8b51e4ca0073'
+down_revision: Union[str, None] = '3c8b03a2c899'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add new columns to productive_consumption
+    op.add_column('productive_consumption', sa.Column('transfer_of_productive_consumption', sa.String(), nullable=True))
+    op.add_column('productive_consumption', sa.Column('transfer_of_compensation', sa.String(), nullable=True))
+
+    # 2. Add a temporary column to transfer for easier linking during migration
+    op.add_column('transfer', sa.Column('temp_original_transaction_id_for_migration_pc', sa.String(), nullable=True)) # Suffix pc to avoid conflict if run in same transaction as other migration
+
+    # 3. Create main 'productive_consumption_p/r' transfers and record original transaction_id
+    op.execute(f'''
+    INSERT INTO transfer (id, date, debit_account, credit_account, value, type, temp_original_transaction_id_for_migration_pc)
+    SELECT 
+        gen_random_uuid()::text,
+        t.date,
+        t.sending_account,
+        t.receiving_account,
+        t.amount_sent,
+        CASE
+            WHEN t.sending_account = c.p_account THEN 'productive_consumption_p'::transfertype
+            WHEN t.sending_account = c.r_account THEN 'productive_consumption_r'::transfertype
+            ELSE NULL -- Should not happen if data is consistent
+        END,
+        t.id -- Store the original transaction_id
+    FROM productive_consumption prod_c
+    JOIN transaction t ON t.id = prod_c.transaction_id
+    JOIN company c ON (t.sending_account = c.p_account OR t.sending_account = c.r_account) -- Assuming sending_account belongs to a company
+    WHERE CASE
+            WHEN t.sending_account = c.p_account THEN 'productive_consumption_p'::transfertype
+            WHEN t.sending_account = c.r_account THEN 'productive_consumption_r'::transfertype
+            ELSE NULL
+          END IS NOT NULL;
+    ''')
+
+    # 4. Populate productive_consumption.transfer_of_productive_consumption
+    op.execute(f'''
+    UPDATE productive_consumption prod_c
+    SET transfer_of_productive_consumption = tr.id
+    FROM transfer tr
+    WHERE tr.temp_original_transaction_id_for_migration_pc = prod_c.transaction_id
+      AND tr.type IN ('productive_consumption_p'::transfertype, 'productive_consumption_r'::transfertype);
+    ''')
+
+    # 5. Create 'compensation' transfers and record original transaction_id
+    op.execute(f'''
+    WITH compensation_data AS (
+        SELECT
+            tr.id as original_transaction_id,
+            tr.date as transaction_date,
+            tr.amount_sent - tr.amount_received as compensation_value,
+            p.planner as planner_company_id,
+            pc_join.cooperation as cooperation_id
+        FROM productive_consumption prod_c_table
+        JOIN transaction tr ON tr.id = prod_c_table.transaction_id
+        JOIN plan p ON p.id = prod_c_table.plan_id
+        JOIN plan_cooperation pc_join ON p.id = pc_join.plan
+        WHERE tr.amount_sent != tr.amount_received
+    )
+    INSERT INTO transfer (id, date, debit_account, credit_account, value, type, temp_original_transaction_id_for_migration_pc)
+    SELECT
+        gen_random_uuid()::text,
+        cd.transaction_date,
+        CASE
+            WHEN cd.compensation_value > 0 THEN comp.prd_account -- compensation_for_coop: company prd_account is debit
+            ELSE coop.account -- compensation_for_company: cooperation account is debit
+        END,
+        CASE
+            WHEN cd.compensation_value > 0 THEN coop.account -- compensation_for_coop: cooperation account is credit
+            ELSE comp.prd_account -- compensation_for_company: company prd_account is credit
+        END,
+        abs(cd.compensation_value),
+        CASE
+            WHEN cd.compensation_value > 0 THEN 'compensation_for_coop'::transfertype
+            ELSE 'compensation_for_company'::transfertype
+        END,
+        cd.original_transaction_id -- Store the original transaction_id
+    FROM compensation_data cd
+    JOIN company comp ON comp.id = cd.planner_company_id
+    JOIN cooperation coop ON coop.id = cd.cooperation_id;
+    ''')
+
+    # 6. Populate productive_consumption.transfer_of_compensation
+    op.execute(f'''
+    UPDATE productive_consumption prod_c
+    SET transfer_of_compensation = tr.id
+    FROM transfer tr
+    WHERE tr.temp_original_transaction_id_for_migration_pc = prod_c.transaction_id
+      AND tr.type IN ('compensation_for_coop'::transfertype, 'compensation_for_company'::transfertype);
+    ''')
+
+    # 7. Drop the temporary column from transfer
+    op.drop_column('transfer', 'temp_original_transaction_id_for_migration_pc')
+
+    # 8. Add foreign key constraints for new columns in productive_consumption
+    op.create_foreign_key('fk_productive_consumption_transfer_pc', 'productive_consumption', 'transfer', ['transfer_of_productive_consumption'], ['id'])
+    op.create_foreign_key('fk_productive_consumption_transfer_comp', 'productive_consumption', 'transfer', ['transfer_of_compensation'], ['id'])
+
+    # 9. Make transfer_of_productive_consumption not nullable
+    op.alter_column('productive_consumption', 'transfer_of_productive_consumption', nullable=False)
+
+    # 10. Drop old foreign key and transaction_id column from productive_consumption
+    op.drop_constraint('productive_consumption_transaction_id_fkey', 'productive_consumption', type_='foreignkey')
+    op.drop_column('productive_consumption', 'transaction_id')
+
+    # 11. Delete the old transactions that were migrated to transfers
+    op.execute(f'''
+    DELETE FROM transaction t
+    WHERE EXISTS (
+        SELECT 1 
+        FROM productive_consumption pc_lookup
+        JOIN transfer main_tr ON main_tr.id = pc_lookup.transfer_of_productive_consumption
+        WHERE main_tr.date = t.date 
+          AND main_tr.debit_account = t.sending_account 
+          AND main_tr.credit_account = t.receiving_account 
+          AND main_tr.value = t.amount_sent
+          AND main_tr.type IN ('productive_consumption_p'::transfertype, 'productive_consumption_r'::transfertype)
+          AND EXISTS (SELECT 1 FROM productive_consumption pc_check WHERE pc_check.transfer_of_productive_consumption = main_tr.id AND pc_check.id = pc_lookup.id)
+    );
+    ''')
+
+
+def downgrade() -> None:
+    # 1. Add back transaction_id column to productive_consumption
+    op.add_column('productive_consumption', sa.Column('transaction_id', sa.String(), nullable=True))
+
+    # 2. Recreate transactions from transfers
+    # This needs to map 'productive_consumption_p' and 'productive_consumption_r' back.
+    # The amount_received is reconstructed based on the main productive consumption transfer and any compensation transfer.
+    op.execute(f'''
+    INSERT INTO transaction (id, date, sending_account, receiving_account, amount_sent, amount_received, purpose)
+    SELECT 
+        gen_random_uuid()::text,
+        t_pc.date,
+        t_pc.debit_account,
+        t_pc.credit_account,
+        t_pc.value, -- This is the original amount_sent
+        CASE
+            WHEN t_comp.id IS NOT NULL AND t_comp.type = 'compensation_for_coop'::transfertype THEN t_pc.value - t_comp.value
+            WHEN t_comp.id IS NOT NULL AND t_comp.type = 'compensation_for_company'::transfertype THEN t_pc.value + t_comp.value
+            ELSE t_pc.value -- No compensation, so amount_received = amount_sent
+        END as amount_received,
+        'Plan-Id: ' || prod_c.plan_id
+    FROM productive_consumption prod_c
+    JOIN transfer t_pc ON t_pc.id = prod_c.transfer_of_productive_consumption
+    LEFT JOIN transfer t_comp ON t_comp.id = prod_c.transfer_of_compensation
+    WHERE t_pc.type IN ('productive_consumption_p'::transfertype, 'productive_consumption_r'::transfertype);
+    ''')
+
+    # 3. Populate transaction_id in productive_consumption by linking to the newly created transactions
+    op.execute(f'''
+    UPDATE productive_consumption prod_c
+    SET transaction_id = t.id
+    FROM transaction t, transfer t_pc
+    WHERE prod_c.transfer_of_productive_consumption = t_pc.id
+      AND t.date = t_pc.date
+      AND t.sending_account = t_pc.debit_account
+      AND t.receiving_account = t_pc.credit_account
+      AND t.amount_sent = t_pc.value
+      AND t_pc.type IN ('productive_consumption_p'::transfertype, 'productive_consumption_r'::transfertype)
+      AND ('Plan-Id: ' || prod_c.plan_id) = t.purpose; -- Added purpose matching for more accuracy
+    ''')
+
+    # 4. Make transaction_id not nullable again
+    op.alter_column('productive_consumption', 'transaction_id', nullable=False)
+
+    # 5. Add back foreign key constraint for transaction_id
+    op.create_foreign_key('productive_consumption_transaction_id_fkey', 'productive_consumption', 'transaction', ['transaction_id'], ['id'])
+
+    # 6. Drop foreign key constraints for transfer columns on productive_consumption FIRST
+    op.drop_constraint('fk_productive_consumption_transfer_comp', 'productive_consumption', type_='foreignkey')
+    op.drop_constraint('fk_productive_consumption_transfer_pc', 'productive_consumption', type_='foreignkey')
+
+    # 7. Delete the transfers that were created by the upgrade.
+    op.execute(f'''
+    DELETE FROM transfer t
+    WHERE t.id IN (
+        SELECT transfer_of_compensation 
+        FROM productive_consumption 
+        WHERE transfer_of_compensation IS NOT NULL
+    ) AND t.type IN ('compensation_for_coop'::transfertype, 'compensation_for_company'::transfertype);
+    ''')
+    op.execute(f'''
+    DELETE FROM transfer t
+    WHERE t.id IN (
+        SELECT transfer_of_productive_consumption 
+        FROM productive_consumption 
+        WHERE transfer_of_productive_consumption IS NOT NULL
+    ) AND t.type IN ('productive_consumption_p'::transfertype, 'productive_consumption_r'::transfertype);
+    ''')
+    
+    # 8. Drop transfer-related columns from productive_consumption
+    op.drop_column('productive_consumption', 'transfer_of_compensation')
+    op.drop_column('productive_consumption', 'transfer_of_productive_consumption')

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -422,9 +422,9 @@ class ConsumptionGenerator:
             consumption_type=consumption_type,
         )
         response = self.register_productive_consumption(request)
-        assert (
-            not response.is_rejected
-        ), f"Could not create productive consumption, response was {response}"
+        if response.is_rejected:
+            assert response.rejection_reason
+            raise response.rejection_reason
         return response
 
     def create_private_consumption(

--- a/tests/services/test_compensation_transfer_service.py
+++ b/tests/services/test_compensation_transfer_service.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.records import Transfer
+from arbeitszeit.repositories import DatabaseGateway
+from arbeitszeit.transfers.compensation import CompensationTransferService
+from arbeitszeit.transfers.transfer_type import TransferType
+from tests.use_cases.base_test_case import BaseTestCase
+
+
+class CompensationTransferServiceTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.service = self.injector.get(CompensationTransferService)
+        self.database_gateway = self.injector.get(DatabaseGateway)
+
+    def test_no_compensation_transfer_created_when_coop_and_plan_price_per_unit_are_equal(
+        self,
+    ) -> None:
+        self.service.create_compensation_transfer(
+            coop_price_per_unit=Decimal(3),
+            plan_price_per_unit=Decimal(3),
+            consumed_amount=1,
+            cooperation_account=uuid4(),
+            planner_product_account=uuid4(),
+        )
+        transfers = self.get_compensation_transfers()
+        assert not transfers
+
+    @parameterized.expand(
+        [
+            (Decimal(15.5), Decimal(11), 1),
+            (Decimal(8), Decimal(4.2), 2),
+            (Decimal(1), Decimal(0), 3),
+        ]
+    )
+    def test_compensation_for_coop_gets_created_when_coop_price_per_unit_is_higher_than_plan_price_per_unit(
+        self,
+        coop_price_per_unit: Decimal,
+        plan_price_per_unit: Decimal,
+        consumed_amount: int,
+    ) -> None:
+        EXPECTED_TYPE = TransferType.compensation_for_coop
+        EXPECTED_TIME = datetime(2025, 1, 1, 10, 15)
+        EXPECTED_DEBIT_ACCOUNT = self.database_gateway.create_account().id
+        EXPECTED_CREDIT_ACCOUNT = self.database_gateway.create_account().id
+        EXPECTED_VALUE = (
+            abs(coop_price_per_unit - plan_price_per_unit) * consumed_amount
+        )
+        self.datetime_service.freeze_time(EXPECTED_TIME)
+        self.service.create_compensation_transfer(
+            coop_price_per_unit=coop_price_per_unit,
+            plan_price_per_unit=plan_price_per_unit,
+            consumed_amount=consumed_amount,
+            cooperation_account=EXPECTED_CREDIT_ACCOUNT,
+            planner_product_account=EXPECTED_DEBIT_ACCOUNT,
+        )
+        self.datetime_service.unfreeze_time()
+        transfers = self.get_compensation_transfers()
+        assert len(transfers) == 1
+        assert transfers[0].date == EXPECTED_TIME
+        assert transfers[0].debit_account == EXPECTED_DEBIT_ACCOUNT
+        assert transfers[0].credit_account == EXPECTED_CREDIT_ACCOUNT
+        assert transfers[0].value == EXPECTED_VALUE
+        assert transfers[0].type == EXPECTED_TYPE
+
+    @parameterized.expand(
+        [
+            (Decimal(11), Decimal(15.5), 1),
+            (Decimal(4.2), Decimal(8), 2),
+            (Decimal(0), Decimal(1), 3),
+        ]
+    )
+    def test_compensation_for_company_gets_created_when_coop_price_per_unit_is_lower_than_plan_price_per_unit(
+        self,
+        coop_price_per_unit: Decimal,
+        plan_price_per_unit: Decimal,
+        consumed_amount: int,
+    ) -> None:
+        EXPECTED_TYPE = TransferType.compensation_for_company
+        EXPECTED_TIME = datetime(2025, 1, 1, 10, 15)
+        EXPECTED_DEBIT_ACCOUNT = self.database_gateway.create_account().id
+        EXPECTED_CREDIT_ACCOUNT = self.database_gateway.create_account().id
+        EXPECTED_VALUE = (
+            abs(coop_price_per_unit - plan_price_per_unit) * consumed_amount
+        )
+        self.datetime_service.freeze_time(EXPECTED_TIME)
+        self.service.create_compensation_transfer(
+            coop_price_per_unit=coop_price_per_unit,
+            plan_price_per_unit=plan_price_per_unit,
+            consumed_amount=consumed_amount,
+            cooperation_account=EXPECTED_DEBIT_ACCOUNT,
+            planner_product_account=EXPECTED_CREDIT_ACCOUNT,
+        )
+        self.datetime_service.unfreeze_time()
+        transfers = self.get_compensation_transfers()
+        assert len(transfers) == 1
+        assert transfers[0].date == EXPECTED_TIME
+        assert transfers[0].debit_account == EXPECTED_DEBIT_ACCOUNT
+        assert transfers[0].credit_account == EXPECTED_CREDIT_ACCOUNT
+        assert transfers[0].value == EXPECTED_VALUE
+        assert transfers[0].type == EXPECTED_TYPE
+
+    def get_compensation_transfers(self) -> list[Transfer]:
+        transfers = self.database_gateway.get_transfers()
+        return list(
+            filter(
+                lambda t: t.type == TransferType.compensation_for_coop
+                or t.type == TransferType.compensation_for_company,
+                transfers,
+            )
+        )

--- a/tests/use_cases/test_register_private_consumption.py
+++ b/tests/use_cases/test_register_private_consumption.py
@@ -430,6 +430,14 @@ class ConsumptionTransferTests(RegisterPrivateConsumptionBase):
 
 
 class CompensationTransferTests(RegisterPrivateConsumptionBase):
+    def test_no_compensation_transfer_created_when_consumed_plan_is_not_cooperating(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        self.consumption_generator.create_private_consumption(plan=plan)
+        transfers = self.get_compensation_transfers()
+        assert not transfers
+
     def test_no_compensation_transfer_created_after_consumption_of_cooperative_product_without_productivity_differences(
         self,
     ) -> None:


### PR DESCRIPTION
**Add CompensationTransferService** 

The service's `create_compensation_transfer` method can be used when registering private as well as productive consumptions.

**Transfers in RegisterProductiveConsumption (business logic)** 

Change the use case for registering productive consumptions to not create one transaction but to create up to two transfers: One consumption transfer and one optional compensation transfer.

This commit only implements business logic changes in `arbeitszeit` folder. Www layer and flask layer will follow in a seperate commit.

**Transfers in productive consumptions (Flask layer)** 

The alembic migration script has been tested successfully (upgrade/downgrade) manually with relevant data in database.

fixes #1239 