### PR TITLE
Upgrade python 3.11 -> 3.12

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4.5.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/development_setup.rst
+++ b/docs/development_setup.rst
@@ -88,9 +88,9 @@ virtual environment by typing ``exit`` at the command prompt.
 Using Nix will give you the option to access a development environment with any of the supported
 python versions via ``nix develop``. Check `flake.nix` for the
 supported environments under the key ``devShells``. For example to
-enter a development shell with ``python3.11`` set as the default
-interpreter run ``nix develop .#python311``. This will drop you into a
-shell with python3.11 as the default python interpreter. This won't
+enter a development shell with ``python3.12`` set as the default
+interpreter run ``nix develop .#python312``. This will drop you into a
+shell with python3.12 as the default python interpreter. This won't
 change anything else on your machine and the respective python
 interpreter will be garbage collected the next time you run
 ``nix-collect-garbage``.

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,8 @@
               includeGlibcLocales = !isMacOs;
               nixfmt = pkgs.nixfmt-rfc-style;
             };
-            python311 = pkgs.callPackage nix/devShell.nix {
-              python3 = pkgs.python311;
+            python312 = pkgs.callPackage nix/devShell.nix {
+              python3 = pkgs.python312;
               includeGlibcLocales = !isMacOs;
             };
           };
@@ -58,9 +58,9 @@
             # python3 interpreter and also explicitly list all
             # versions we want to support.
             arbeitszeit-python3-nixpkgs-unstable = pkgs.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python311-nixpkgs-unstable = pkgs.python311.pkgs.arbeitszeitapp;
+            arbeitszeit-python312-nixpkgs-unstable = pkgs.python312.pkgs.arbeitszeitapp;
             arbeitszeit-python3-nixpkgs-stable = pkgs-24-11.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python311-nixpkgs-stable = pkgs-24-11.python311.pkgs.arbeitszeitapp;
+            arbeitszeit-python312-nixpkgs-stable = pkgs-24-11.python312.pkgs.arbeitszeitapp;
           };
         }
       );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "arbeitszeitapp"
 version = "0.0.0"
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.optional-dependencies]
@@ -28,7 +28,7 @@ include = [
 ]
 
 [tool.black]
-target-version = ['py311']
+target-version = ['py312']
 extend-exclude = '''
 (
   ^/arbeitszeit_flask/development_settings\.py |


### PR DESCRIPTION
This commit deprecates Python 3.11. Instead, now we support Python 3.12 explicitly. Moreover, we support 3.13 implicitly (because channel nixpkgs-unstable currently uses Python 3.13.x).