### PR TITLE
Drop and recreate test db schema once per testrun

### DIFF
--- a/tests/flask_integration/test_db_migrations.py
+++ b/tests/flask_integration/test_db_migrations.py
@@ -40,7 +40,7 @@ class AutoMigrationTests(AutoMigrationsTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        drop_and_recreate_schema(self.connection)
+        drop_and_recreate_schema(self.db.engine.connect())
 
     def test_that_app_starts_successfully_when_auto_migrate_is_enabled(self) -> None:
         self.injector.get(Flask)


### PR DESCRIPTION
This enhances testrun isolation.