### PR TITLE
Delete unused social accounting account

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -19,7 +19,6 @@ class EmailAddress:
 @dataclass
 class SocialAccounting:
     id: UUID
-    account: UUID
     account_psf: UUID
 
     def get_name(self) -> str:

--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -25,16 +25,6 @@ class SocialAccounting:
     def get_name(self) -> str:
         return "Social Accounting"
 
-    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
-        if account == self.account:
-            return AccountTypes.accounting
-        if account == self.account_psf:
-            return AccountTypes.psf
-        return None
-
-    def is_member(self) -> bool:
-        return False
-
 
 @dataclass
 class Member:
@@ -43,25 +33,8 @@ class Member:
     account: UUID
     registered_on: datetime
 
-    def accounts(self) -> List[UUID]:
-        return [self.account]
-
     def get_name(self) -> str:
         return self.name
-
-    def get_account_by_type(self, account_type: AccountTypes) -> Optional[UUID]:
-        if account_type == AccountTypes.member:
-            return self.account
-        return None
-
-    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
-        if self.account == account:
-            return AccountTypes.member
-        else:
-            return None
-
-    def is_member(self) -> bool:
-        return True
 
 
 @dataclass
@@ -91,18 +64,6 @@ class Company:
     def get_account_by_type(self, account_type: AccountTypes) -> Optional[UUID]:
         return self._accounts_by_type().get(account_type)
 
-    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
-        account_types = {
-            self.means_account: AccountTypes.p,
-            self.raw_material_account: AccountTypes.r,
-            self.work_account: AccountTypes.a,
-            self.product_account: AccountTypes.prd,
-        }
-        return account_types.get(account)
-
-    def is_member(self) -> bool:
-        return False
-
 
 class AccountTypes(Enum):
     p = "p"
@@ -130,11 +91,6 @@ class Cooperation:
 
     def get_name(self) -> str:
         return self.name
-
-    def get_account_type(self, account: UUID) -> Optional[AccountTypes]:
-        if account == self.account:
-            return AccountTypes.cooperation
-        return None
 
 
 @dataclass

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -40,7 +40,6 @@ class SocialAccounting(Base):
     __tablename__ = "social_accounting"
 
     id: Mapped[str] = mapped_column(primary_key=True, default=generate_uuid)
-    account: Mapped[str] = mapped_column(ForeignKey("account.id"))
     account_psf: Mapped[str] = mapped_column(ForeignKey("account.id"))
 
 

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -998,10 +998,7 @@ class AccountQueryResult(FlaskQueryResult[records.Account]):
             )
             .join(
                 social_accounting,
-                or_(
-                    social_accounting.account == models.Account.id,
-                    social_accounting.account_psf == models.Account.id,
-                ),
+                social_accounting.account_psf == models.Account.id,
                 isouter=True,
             )
             .join(cooperation, cooperation.account == models.Account.id, isouter=True)
@@ -1998,7 +1995,6 @@ class AccountingRepository:
     ) -> records.SocialAccounting:
         return records.SocialAccounting(
             id=UUID(accounting_orm.id),
-            account=UUID(accounting_orm.account),
             account_psf=UUID(accounting_orm.account_psf),
         )
 
@@ -2013,9 +2009,7 @@ class AccountingRepository:
             social_accounting = SocialAccounting(
                 id=str(uuid4()),
             )
-            account = self.database_gateway.create_account()
             account_psf = self.database_gateway.create_account()
-            social_accounting.account = str(account.id)
             social_accounting.account_psf = str(account_psf.id)
             self.db.session.add(social_accounting)
             self.db.session.flush()

--- a/arbeitszeit_flask/migrations/versions/4fd90069eb82_remove_social_accounting_account.py
+++ b/arbeitszeit_flask/migrations/versions/4fd90069eb82_remove_social_accounting_account.py
@@ -1,0 +1,50 @@
+"""Remove social accounting account
+
+Revision ID: 4fd90069eb82
+Revises: 480a749375de
+Create Date: 2025-08-02 07:20:54.450970
+
+"""
+from typing import Sequence, Union
+from uuid import uuid4
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4fd90069eb82'
+down_revision: Union[str, None] = '480a749375de'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('social_accounting_account_fkey', 'social_accounting', type_='foreignkey')
+    op.drop_column('social_accounting', 'account')
+
+
+def downgrade() -> None:
+    op.add_column('social_accounting', sa.Column('account', sa.VARCHAR(), autoincrement=False, nullable=True))
+    
+    # Generate a valid account ID and add it to the social_accounting table.
+    social_accounting = table('social_accounting', column('account', sa.VARCHAR()))
+    op.execute(social_accounting.update().values(account=generate_valid_account_id()))
+    
+    op.alter_column('social_accounting', 'account', nullable=False)
+    op.create_foreign_key('social_accounting_account_fkey', 'social_accounting', 'account', ['account'], ['id'])
+
+
+def generate_valid_account_id() -> str:
+    conn = op.get_bind()
+    new_id = generate_uuid()
+    conn.execute(
+        sa.text("INSERT INTO account (id) VALUES (:id)"),
+        {"id": new_id}
+    )
+    return new_id
+
+
+def generate_uuid() -> str:
+    return str(uuid4())

--- a/tests/flask_integration/database_gateway_impl/test_account_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_result.py
@@ -12,11 +12,11 @@ from ..flask import FlaskTestCase
 
 
 class AccountResultTests(FlaskTestCase):
-    def test_that_a_priori_there_are_two_accounts_for_social_accounting(
+    def test_that_by_default_there_is_one_account_for_social_accounting(
         self,
     ) -> None:
         self.injector.get(SocialAccounting)
-        assert len(self.database_gateway.get_accounts()) == 2
+        assert len(self.database_gateway.get_accounts()) == 1
 
     def test_there_are_accounts_to_be_queried_when_one_was_created(self) -> None:
         self.database_gateway.create_account()
@@ -93,20 +93,6 @@ class AccountResultTests(FlaskTestCase):
         )
         assert result
         assert company == result[1]
-
-    def test_account_from_social_accounting_joined_with_owner_yields_account_and_social_accounting_itself(
-        self,
-    ) -> None:
-        social_accounting = self.injector.get(SocialAccounting)
-        result = (
-            self.database_gateway.get_accounts()
-            .with_id(social_accounting.account)
-            .joined_with_owner()
-            .first()
-        )
-        assert result
-        assert result[0].id == social_accounting.account
-        assert result[1] == social_accounting
 
     def test_psf_account_from_social_accounting_joined_with_owner_yields_psf_account_and_social_accounting_itself(
         self,

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -1202,7 +1202,7 @@ class AccountResult(QueryResultImpl[Account]):
     ) -> QueryResultImpl[Tuple[Account, records.AccountOwner]]:
         def items() -> Iterable[Tuple[Account, records.AccountOwner]]:
             for account in self.items():
-                if account.id == self.database.social_accounting.account:
+                if account.id == self.database.social_accounting.account_psf:
                     yield account, self.database.social_accounting
                 for member in self.database.members.values():
                     if account.id == member.account:
@@ -1686,7 +1686,6 @@ class MockDatabase:
         self.accountants: Dict[UUID, Accountant] = dict()
         self.social_accounting = SocialAccounting(
             id=uuid4(),
-            account=self.create_account().id,
             account_psf=self.create_account().id,
         )
         self.cooperations: Dict[UUID, Cooperation] = dict()


### PR DESCRIPTION
- Delete dead code in records.py
- Delete general account of social accounting 
With the new transfer system social accounting needs only one "psf" account.

fixes #1268