### PR TITLE
Remove unneded dataclass conversions

### DIFF
--- a/arbeitszeit_flask/accountant/routes.py
+++ b/arbeitszeit_flask/accountant/routes.py
@@ -103,7 +103,7 @@ def plan_details(
         return FlaskResponse(
             render_template(
                 "accountant/plan_details.html",
-                view_model=view_model.to_dict(),
+                view_model=view_model,
             )
         )
     else:

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -245,7 +245,7 @@ def plan_details(
     if not use_case_response:
         return http_404()
     view_model = presenter.present(use_case_response)
-    return render_template("company/plan_details.html", view_model=view_model.to_dict())
+    return render_template("company/plan_details.html", view_model=view_model)
 
 
 @CompanyRoute(

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -93,7 +93,7 @@ class plan_details:
             return FlaskResponse(
                 render_template(
                     "member/plan_details.html",
-                    view_model=view_model.to_dict(),
+                    view_model=view_model,
                 )
             )
         else:

--- a/arbeitszeit_flask/user/routes.py
+++ b/arbeitszeit_flask/user/routes.py
@@ -72,7 +72,7 @@ def company_summary(
         view_model = presenter.present(use_case_response)
         return render_template(
             "user/company_summary.html",
-            view_model=view_model.to_dict(),
+            view_model=view_model,
         )
     else:
         return http_404()

--- a/arbeitszeit_flask/views/coop_summary_view.py
+++ b/arbeitszeit_flask/views/coop_summary_view.py
@@ -23,8 +23,6 @@ class CoopSummaryView:
         )
         if use_case_response:
             view_model = self.presenter.present(use_case_response)
-            return render_template(
-                "user/coop_summary.html", view_model=view_model.to_dict()
-            )
+            return render_template("user/coop_summary.html", view_model=view_model)
         else:
             return http_404()

--- a/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
@@ -1,5 +1,5 @@
-from dataclasses import asdict, dataclass
-from typing import Any, Dict, List
+from dataclasses import dataclass
+from typing import List
 
 from arbeitszeit.control_thresholds import ControlThresholds
 from arbeitszeit.use_cases.get_company_summary import (
@@ -52,9 +52,6 @@ class GetCompanySummaryViewModel:
     r_account_overview_url: str
     a_account_overview_url: str
     prd_account_overview_url: str
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/arbeitszeit_web/www/presenters/get_coop_summary_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_coop_summary_presenter.py
@@ -1,6 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from arbeitszeit.use_cases.get_coop_summary import GetCoopSummaryResponse
 
@@ -31,9 +31,6 @@ class GetCoopSummaryViewModel:
     coop_price: str
 
     plans: List[AssociatedPlan]
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/arbeitszeit_web/www/presenters/get_plan_details_accountant_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_plan_details_accountant_presenter.py
@@ -1,5 +1,4 @@
-from dataclasses import asdict, dataclass
-from typing import Any, Dict
+from dataclasses import dataclass
 
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
 from arbeitszeit_web.formatters.plan_details_formatter import (
@@ -14,9 +13,6 @@ from ...translator import Translator
 @dataclass
 class GetPlanDetailsAccountantViewModel:
     details: PlanDetailsWeb
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/arbeitszeit_web/www/presenters/get_plan_details_company_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_plan_details_company_presenter.py
@@ -1,5 +1,5 @@
-from dataclasses import asdict, dataclass
-from typing import Any, Dict, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from arbeitszeit.plan_details import PlanDetails
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
@@ -27,9 +27,6 @@ class GetPlanDetailsCompanyViewModel:
     own_plan_action: OwnPlanAction
     show_productive_consumption_url: bool
     productive_consumption_url: str
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/arbeitszeit_web/www/presenters/get_plan_details_member_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_plan_details_member_presenter.py
@@ -1,5 +1,4 @@
-from dataclasses import asdict, dataclass
-from typing import Any, Dict
+from dataclasses import dataclass
 
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
 from arbeitszeit_web.formatters.plan_details_formatter import (
@@ -15,9 +14,6 @@ from ...translator import Translator
 class GetPlanDetailsMemberViewModel:
     details: PlanDetailsWeb
     register_private_consumption_url: str
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/arbeitszeit_web/www/presenters/query_companies_presenter.py
+++ b/arbeitszeit_web/www/presenters/query_companies_presenter.py
@@ -1,5 +1,5 @@
-from dataclasses import asdict, dataclass
-from typing import Any, Dict, List
+from dataclasses import dataclass
+from typing import List
 
 from arbeitszeit.use_cases.query_companies import CompanyQueryResponse
 from arbeitszeit_web.notification import Notifier
@@ -28,9 +28,6 @@ class QueryCompaniesViewModel:
     results: ResultsTable
     show_results: bool
     pagination: Pagination
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass


### PR DESCRIPTION
We can access the fields of a dataclass in a jinja template using the dot notation without having to convert it to a dictionary first.