### PR TITLE
Changes on pagination

### DIFF
--- a/arbeitszeit_flask/views/query_plans.py
+++ b/arbeitszeit_flask/views/query_plans.py
@@ -43,7 +43,7 @@ class QueryPlansView:
         form: PlanSearchForm,
     ) -> Response:
         response = self.query_plans(use_case_request)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         return Response(self._render_response_content(view_model, form=form))
 
     def _render_response_content(

--- a/arbeitszeit_web/pagination.py
+++ b/arbeitszeit_web/pagination.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Dict, List
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from typing import List
+from urllib.parse import urlencode, urlparse, urlunparse
 
 from arbeitszeit_web.request import Request
 
@@ -26,24 +26,18 @@ class Pagination:
 class Paginator:
     def __init__(
         self,
-        base_url: str,
-        query_arguments: Dict[str, str],
-        page_size: int,
+        request: Request,
         total_results: int,
-        current_offset: int,
+        page_size: int = DEFAULT_PAGE_SIZE,
     ) -> None:
-        self.parsed_url = urlparse(base_url)
-        self.query_arguments = query_arguments
-        self.parsed_query_arguments: Dict[str, str] = {
-            key: values[0] for key, values in parse_qs(self.parsed_url.query).items()
-        }
-        self.parsed_query_arguments.update(query_arguments)
+        self.parsed_url = urlparse(request.get_request_target())
+        self.query_arguments: dict[str, str] = dict(request.query_string().items())
         self.page_size = page_size
         self.total_results = total_results
-        self.current_offset = current_offset
+        self.current_offset = calculate_current_offset(request, self.page_size)
 
     def get_page_link(self, page: int) -> str:
-        query = dict(self.parsed_query_arguments)
+        query = dict(self.query_arguments)
         query[PAGE_PARAMETER_NAME] = str(page)
         modified_parsed = self.parsed_url._replace(query=urlencode(query))
         return urlunparse(modified_parsed)
@@ -56,11 +50,11 @@ class Paginator:
                 href=self.get_page_link(page=n),
                 is_current=current_page_number == n,
             )
-            for n in range(1, self.page_count + 1)
+            for n in range(1, self.number_of_pages + 1)
         ]
 
     @property
-    def page_count(self) -> int:
+    def number_of_pages(self) -> int:
         return 1 + (self.total_results - 1) // self.page_size
 
 

--- a/arbeitszeit_web/pagination.py
+++ b/arbeitszeit_web/pagination.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import Dict, List
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+from arbeitszeit_web.request import Request
+
 PAGE_PARAMETER_NAME = "page"
 """The name of the request query parameter used for pagination."""
 
@@ -60,3 +62,14 @@ class Paginator:
     @property
     def page_count(self) -> int:
         return 1 + (self.total_results - 1) // self.page_size
+
+
+def calculate_current_offset(request: Request, limit: int) -> int:
+    page_number_str = request.query_string().get_last_value(PAGE_PARAMETER_NAME)
+    if page_number_str is None:
+        return 0
+    try:
+        page_number = int(page_number_str)
+    except ValueError:
+        return 0
+    return (page_number - 1) * limit

--- a/arbeitszeit_web/www/controllers/query_companies_controller.py
+++ b/arbeitszeit_web/www/controllers/query_companies_controller.py
@@ -1,7 +1,7 @@
 from typing import Optional, Protocol
 
 from arbeitszeit.use_cases.query_companies import CompanyFilter, QueryCompaniesRequest
-from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, PAGE_PARAMETER_NAME
+from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, calculate_current_offset
 from arbeitszeit_web.request import Request
 
 
@@ -9,9 +9,6 @@ class QueryCompaniesFormData(Protocol):
     def get_query_string(self) -> str: ...
 
     def get_category_string(self) -> str: ...
-
-
-_page_size = DEFAULT_PAGE_SIZE
 
 
 class QueryCompaniesController:
@@ -30,20 +27,10 @@ class QueryCompaniesController:
                 filter_category = CompanyFilter.by_email
             else:
                 filter_category = CompanyFilter.by_name
-        offset = self._get_pagination_offset(request)
+        offset = calculate_current_offset(request=request, limit=DEFAULT_PAGE_SIZE)
         return QueryCompaniesRequest(
             query_string=query,
             filter_category=filter_category,
             offset=offset,
-            limit=_page_size,
+            limit=DEFAULT_PAGE_SIZE,
         )
-
-    def _get_pagination_offset(self, request: Request) -> int:
-        page_str = request.query_string().get_last_value(PAGE_PARAMETER_NAME)
-        if page_str is None:
-            return 0
-        try:
-            page_number = int(page_str)
-        except ValueError:
-            return 0
-        return (page_number - 1) * _page_size

--- a/arbeitszeit_web/www/controllers/query_plans_controller.py
+++ b/arbeitszeit_web/www/controllers/query_plans_controller.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional, Protocol
 
 from arbeitszeit.use_cases.query_plans import PlanFilter, PlanSorting, QueryPlansRequest
-from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, PAGE_PARAMETER_NAME
+from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, calculate_current_offset
 from arbeitszeit_web.request import Request
 
 
@@ -33,7 +33,11 @@ class QueryPlansController:
             filter_category = self._import_filter_category(form)
             sorting_category = self._import_sorting_category(form)
             include_expired_plans = self._import_include_expired(form)
-        offset = self._get_pagination_offset(request) if request else 0
+        offset = (
+            calculate_current_offset(request=request, limit=DEFAULT_PAGE_SIZE)
+            if request
+            else 0
+        )
         return QueryPlansRequest(
             query_string=query,
             filter_category=filter_category,
@@ -42,16 +46,6 @@ class QueryPlansController:
             offset=offset,
             limit=DEFAULT_PAGE_SIZE,
         )
-
-    def _get_pagination_offset(self, request: Request) -> int:
-        page_str = request.query_string().get_last_value(PAGE_PARAMETER_NAME)
-        if page_str is None:
-            return 0
-        try:
-            page_number = int(page_str)
-        except ValueError:
-            return 0
-        return (page_number - 1) * DEFAULT_PAGE_SIZE
 
     def _import_filter_category(self, form: QueryPlansFormData) -> PlanFilter:
         if form.get_category_string() == "Plan-ID":

--- a/arbeitszeit_web/www/presenters/query_plans_presenter.py
+++ b/arbeitszeit_web/www/presenters/query_plans_presenter.py
@@ -2,9 +2,8 @@ from dataclasses import dataclass
 
 from arbeitszeit.use_cases.query_plans import PlanQueryResponse
 from arbeitszeit_web.notification import Notifier
-from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, Pagination, Paginator
+from arbeitszeit_web.pagination import Pagination, Paginator
 from arbeitszeit_web.request import Request
-from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex, UserUrlIndex
 
@@ -40,19 +39,12 @@ class QueryPlansPresenter:
     user_url_index: UserUrlIndex
     url_index: UrlIndex
     user_notifier: Notifier
-    trans: Translator
-    session: Session
+    translator: Translator
+    request: Request
 
-    def present(
-        self, response: PlanQueryResponse, request: Request
-    ) -> QueryPlansViewModel:
+    def present(self, response: PlanQueryResponse) -> QueryPlansViewModel:
         if not response.results:
-            self.user_notifier.display_warning(self.trans.gettext("No results."))
-        paginator = self._create_paginator(
-            request,
-            total_results=response.total_results,
-            current_offset=response.request.offset or 0,
-        )
+            self.user_notifier.display_warning(self.translator.gettext("No results."))
         return QueryPlansViewModel(
             total_results=response.total_results,
             show_results=bool(response.results),
@@ -76,10 +68,7 @@ class QueryPlansPresenter:
                     for result in response.results
                 ],
             ),
-            pagination=Pagination(
-                is_visible=paginator.page_count > 1,
-                pages=paginator.get_pages(),
-            ),
+            pagination=self._create_pagination(response),
         )
 
     def get_empty_view_model(self) -> QueryPlansViewModel:
@@ -90,16 +79,12 @@ class QueryPlansPresenter:
             pagination=Pagination(is_visible=False, pages=[]),
         )
 
-    def _create_paginator(
-        self, request: Request, total_results: int, current_offset: int
-    ) -> Paginator:
-        return Paginator(
-            base_url=self._get_pagination_base_url(),
-            query_arguments=dict(request.query_string().items()),
-            page_size=DEFAULT_PAGE_SIZE,
-            total_results=total_results,
-            current_offset=current_offset,
+    def _create_pagination(self, response: PlanQueryResponse) -> Pagination:
+        paginator = Paginator(
+            request=self.request,
+            total_results=response.total_results,
         )
-
-    def _get_pagination_base_url(self) -> str:
-        return self.url_index.get_query_plans_url()
+        return Pagination(
+            is_visible=paginator.number_of_pages > 1,
+            pages=paginator.get_pages(),
+        )

--- a/tests/request.py
+++ b/tests/request.py
@@ -68,4 +68,7 @@ class FakeRequest:
         self._json = value
 
     def get_request_target(self) -> str:
-        return "/"
+        return self._environ.get("REQUEST_URI", "http://example.com/")
+
+    def set_request_target(self, url: str) -> None:
+        self._environ["REQUEST_URI"] = url

--- a/tests/www/presenters/test_query_companies_presenter.py
+++ b/tests/www/presenters/test_query_companies_presenter.py
@@ -1,6 +1,8 @@
 from uuid import uuid4
 
-from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE
+from parameterized import parameterized
+
+from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE, PAGE_PARAMETER_NAME
 from arbeitszeit_web.www.presenters.query_companies_presenter import (
     QueryCompaniesPresenter,
 )
@@ -81,3 +83,23 @@ class PaginationTests(BaseTestCase):
         )
         view_model = self.presenter.present(response)
         assert view_model.pagination.is_visible
+
+    @parameterized.expand(
+        [
+            (1,),
+            (2,),
+            (3,),
+        ]
+    )
+    def test_that_correct_pages_are_shown_as_currently_selected(
+        self,
+        page_number_in_query_string: int,
+    ) -> None:
+        self.request.set_arg(PAGE_PARAMETER_NAME, str(page_number_in_query_string))
+        response = self.queried_company_generator.get_response()
+        view_model = self.presenter.present(response)
+        for index, page in enumerate(view_model.pagination.pages):
+            if index == page_number_in_query_string - 1:
+                assert page.is_current
+            else:
+                assert not page.is_current

--- a/tests/www/presenters/test_query_plans_presenter.py
+++ b/tests/www/presenters/test_query_plans_presenter.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from parameterized import parameterized
 
+from arbeitszeit_web.pagination import PAGE_PARAMETER_NAME
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.query_plans_presenter import QueryPlansPresenter
 from tests.www.base_test_case import BaseTestCase
@@ -18,7 +19,7 @@ class QueryPlansPresenterTests(BaseTestCase):
 
     def test_presenting_empty_response_leads_to_not_showing_results(self) -> None:
         response = self.queried_plan_generator.get_response([])
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         self.assertFalse(presentation.show_results)
 
     def test_empty_view_model_does_not_show_results(self) -> None:
@@ -29,19 +30,19 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan()]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         self.assertTrue(presentation.show_results)
 
     def test_show_warning_when_no_results_are_found(self) -> None:
         response = self.queried_plan_generator.get_response([])
-        self.presenter.present(response, self.request)
+        self.presenter.present(response)
         self.assertTrue(self.notifier.warnings)
 
     def test_dont_show_warning_when_results_are_found(self) -> None:
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan()]
         )
-        self.presenter.present(response, self.request)
+        self.presenter.present(response)
         self.assertFalse(self.notifier.warnings)
 
     @parameterized.expand(
@@ -59,7 +60,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             total_results=number_of_results
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         self.assertEqual(presentation.total_results, number_of_results)
 
     def test_correct_plan_url_is_shown(self) -> None:
@@ -67,7 +68,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(plan_id=plan_id)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.plan_details_url,
@@ -81,7 +82,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(company_id=company_id)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.company_summary_url,
@@ -92,7 +93,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan()]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(table_row.company_name, "Planner name")
 
@@ -100,7 +101,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(is_cooperating=False)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.is_cooperating,
@@ -111,7 +112,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(is_cooperating=True)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.is_cooperating,
@@ -122,7 +123,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan()]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.is_public_service,
@@ -136,7 +137,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(is_expired=is_expired)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertEqual(
             table_row.is_expired,
@@ -147,7 +148,7 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan()]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertIn("For eatingNext paragraphThird one", table_row.description)
 
@@ -158,71 +159,86 @@ class QueryPlansPresenterTests(BaseTestCase):
         response = self.queried_plan_generator.get_response(
             [self.queried_plan_generator.get_plan(description=description)]
         )
-        presentation = self.presenter.present(response, self.request)
+        presentation = self.presenter.present(response)
         table_row = presentation.results.rows[0]
         self.assertIn(expected_substring, table_row.description)
         self.assertNotIn(unexpected_substring, table_row.description)
 
     def test_that_with_only_1_plan_in_response_no_page_links_are_returned(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=1)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert not view_model.pagination.is_visible
 
     def test_that_with_16_plans_in_response_the_pagination_is_visible(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=16)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert view_model.pagination.is_visible
 
     def test_that_with_15_plans_in_response_the_pagination_is_not_visible(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=15)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert not view_model.pagination.is_visible
 
     def test_that_with_16_plans_there_are_2_pages(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=16)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert len(view_model.pagination.pages) == 2
 
     def test_that_with_31_plans_there_are_3_pages(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=31)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert len(view_model.pagination.pages) == 3
 
     def test_that_with_30_plans_there_are_2_pages(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=30)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert len(view_model.pagination.pages) == 2
 
     def test_that_label_of_first_page_is_1(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=30)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert view_model.pagination.pages[0].label == "1"
 
     def test_that_label_of_second_page_is_2(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=30)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert view_model.pagination.pages[1].label == "2"
 
     def test_with_requested_offset_of_0_the_first_page_is_current(self) -> None:
         response = self.queried_plan_generator.get_response(requested_offset=0)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert view_model.pagination.pages[0].is_current
 
     def test_with_requested_offset_of_0_the_second_page_is_not_current(self) -> None:
         response = self.queried_plan_generator.get_response(
             requested_offset=0, total_results=30
         )
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         assert not view_model.pagination.pages[1].is_current
 
-    def test_with_requested_offset_of_15_the_first_page_is_not_current(self) -> None:
-        response = self.queried_plan_generator.get_response(requested_offset=15)
-        view_model = self.presenter.present(response, self.request)
-        assert not view_model.pagination.pages[0].is_current
+    @parameterized.expand(
+        [
+            (1,),
+            (2,),
+            (3,),
+        ]
+    )
+    def test_that_correct_pages_are_shown_as_currently_selected(
+        self,
+        page_number_in_query_string: int,
+    ) -> None:
+        self.request.set_arg(PAGE_PARAMETER_NAME, str(page_number_in_query_string))
+        response = self.queried_plan_generator.get_response(total_results=100)
+        view_model = self.presenter.present(response)
+        for index, page in enumerate(view_model.pagination.pages):
+            if index == page_number_in_query_string - 1:
+                assert page.is_current
+            else:
+                assert not page.is_current
 
     def test_that_page_links_generated_contain_page_number_in_query_args(self) -> None:
         response = self.queried_plan_generator.get_response(total_results=45)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         for n, page in enumerate(view_model.pagination.pages):
             self._assertQueryArg(page.href, name="page", value=str(n + 1))
 
@@ -233,28 +249,24 @@ class QueryPlansPresenterTests(BaseTestCase):
         expected_value = "value123"
         self.request.set_arg(expected_name, expected_value)
         response = self.queried_plan_generator.get_response(total_results=1)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         self._assertQueryArg(
             view_model.pagination.pages[0].href,
             name=expected_name,
             value=expected_value,
         )
 
-    def test_that_page_links_lead_to_query_plans_site_for_members(self) -> None:
+    def test_that_page_links_lead_to_same_scheme_and_domain_as_original_page(
+        self,
+    ) -> None:
+        expected_url = "url://some_url_with_pagination"
+        self.request.set_request_target(expected_url)
         self.session.login_member(uuid4())
         response = self.queried_plan_generator.get_response(total_results=1)
-        view_model = self.presenter.present(response, self.request)
+        view_model = self.presenter.present(response)
         page_url = view_model.pagination.pages[0].href
-        self._assertSameUrlScheme(page_url, self.url_index.get_query_plans_url())
-        self._assertSameUrlDomain(page_url, self.url_index.get_query_plans_url())
-
-    def test_that_page_links_lead_to_query_plans_site_for_companies(self) -> None:
-        self.session.login_company(uuid4())
-        response = self.queried_plan_generator.get_response(total_results=1)
-        view_model = self.presenter.present(response, self.request)
-        page_url = view_model.pagination.pages[0].href
-        self._assertSameUrlScheme(page_url, self.url_index.get_query_plans_url())
-        self._assertSameUrlDomain(page_url, self.url_index.get_query_plans_url())
+        self._assertSameUrlScheme(page_url, expected_url)
+        self._assertSameUrlDomain(page_url, expected_url)
 
     def _assertQueryArg(self, url: str, *, name: str, value: str) -> None:
         query_args = parse_qs(urlparse(url).query)


### PR DESCRIPTION
- Refactor pagination of controllers 

  Reduce code duplication in two controllers by creating a shared function, "calculate_current_offset".

- Simplify usage of Paginator

  By passing the web request object to the Paginator, we were able to simplify the usage of this class.

  This commit is based on the design decision that 1) presenters in arbeitszeit_web/www_presenters may expect a http web request protocol class (this is a slight deviation from the clean code architecture concept that assigns the presenter only the task to work with use case output) and 2) that the Paginator class expects a http web request.

  Presenters and the paginator class can therefore be considered http-specfic. The partial effort to clean presenters from web requests is abandoned. The alternative would be to pass transport-specific information through the use case, which would be a larger deviation from clean architecture principles.