### PR TITLE
Use UTC timezone internally

### DIFF
--- a/arbeitszeit/datetime_service.py
+++ b/arbeitszeit/datetime_service.py
@@ -1,8 +1,6 @@
-from datetime import date, datetime
+from datetime import datetime
 from typing import Protocol
 
 
 class DatetimeService(Protocol):
-    def today(self) -> date: ...
-
     def now(self) -> datetime: ...

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -8,7 +8,6 @@ from jinja2 import StrictUndefined
 from arbeitszeit_flask.babel import initialize_babel
 from arbeitszeit_flask.database.db import Database
 from arbeitszeit_flask.database.models import Base
-from arbeitszeit_flask.datetime import RealtimeDatetimeService
 from arbeitszeit_flask.extensions import csrf_protect, login_manager
 from arbeitszeit_flask.filters import icon_filter
 from arbeitszeit_flask.mail_service import load_email_plugin
@@ -89,8 +88,6 @@ def create_app(
     def shutdown_session(exception: BaseException | None = None) -> None:
         db.session.remove()
 
-    # Set up template filters
-    app.template_filter()(RealtimeDatetimeService().format_datetime)
     app.template_filter("icon")(icon_filter)
 
     with app.app_context():

--- a/arbeitszeit_flask/datetime.py
+++ b/arbeitszeit_flask/datetime.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from dateutil import tz
@@ -8,7 +8,7 @@ from arbeitszeit.datetime_service import DatetimeService
 
 class RealtimeDatetimeService(DatetimeService):
     def now(self) -> datetime:
-        return datetime.now()
+        return datetime.now(UTC)
 
     def format_datetime(
         self,

--- a/arbeitszeit_flask/datetime.py
+++ b/arbeitszeit_flask/datetime.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 from typing import Optional
 
 from dateutil import tz
@@ -9,9 +9,6 @@ from arbeitszeit.datetime_service import DatetimeService
 class RealtimeDatetimeService(DatetimeService):
     def now(self) -> datetime:
         return datetime.now()
-
-    def today(self) -> date:
-        return datetime.today().date()
 
     def format_datetime(
         self,

--- a/arbeitszeit_web/www/presenters/get_coordination_transfer_request_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_coordination_transfer_request_details_presenter.py
@@ -31,7 +31,11 @@ class GetCoordinationTransferRequestDetailsPresenter:
         current_user = self.session.get_current_user()
         assert current_user
         return self.ViewModel(
-            request_date=self.datetime_formatter.format_datetime(response.request_date),
+            request_date=self.datetime_formatter.format_datetime(
+                response.request_date,
+                zone="Europe/Berlin",
+                fmt="%d.%m.%Y %H:%M",
+            ),
             cooperation_url=self.url_index.get_coop_summary_url(
                 coop_id=response.cooperation_id
             ),

--- a/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
@@ -31,6 +31,7 @@ class PrivateConsumptionsPresenter:
                     consumption_date=self.datetime_formatter.format_datetime(
                         date=consumption.consumption_date,
                         fmt="%d.%m.%Y",
+                        zone="Europe/Berlin",
                     ),
                     product_name=consumption.product_name,
                     product_description=consumption.product_description,

--- a/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
@@ -42,7 +42,11 @@ class ReviewRegisteredConsumptionsPresenter:
 
     def _create_consumption(self, consumption: RegisteredConsumption) -> Consumption:
         return Consumption(
-            date=self.datetime_formatter.format_datetime(consumption.date),
+            date=self.datetime_formatter.format_datetime(
+                consumption.date,
+                fmt="%d.%m.%Y %H:%M",
+                zone="Europe/Berlin",
+            ),
             consumer_name=consumption.consumer_name,
             consumer_url=self._get_consumer_url(consumption),
             consumer_type_icon=self._get_consumer_type_icon(consumption),

--- a/docs/development_guide.rst
+++ b/docs/development_guide.rst
@@ -564,6 +564,14 @@ handler for this path must accept a ``member_id`` argument of type
             return f"Deleting member account for member {member_id}"
 
 
+Date and Time Handling
+-----------------------
+
+We work internally with the UTC timezone. To this end we use timezone-aware python 
+datetime objects wherever possible. We convert datetime to the required timezone 
+only in the presenter layer.
+
+
 Icon Templates: Integration and Usage
 -----------------------------------------
 

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -22,7 +22,6 @@ mkShell (
         pip
         psycopg2
         types-dateutil
-        types-pytz
         types-setuptools
       ])
       ++ [

--- a/nix/pythonPackages/flask-restx.nix
+++ b/nix/pythonPackages/flask-restx.nix
@@ -5,7 +5,6 @@
   flask,
   aniso8601,
   jsonschema,
-  pytz,
   werkzeug,
   importlib-resources,
 }:
@@ -21,7 +20,6 @@ buildPythonPackage rec {
     flask
     aniso8601
     jsonschema
-    pytz
     werkzeug
     importlib-resources
   ];

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,6 @@ pytest
 sphinx
 sphinx-rtd-theme
 types-python-dateutil
-types-pytz
 types-setuptools
 
 git+https://github.com/seppeljordan/flask-profiler.git#egg=flask-profiler

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -45,20 +45,5 @@ class FakeDatetimeService(DatetimeService):
             fmt = "%d.%m.%Y %H:%M"
         return date.strftime(fmt)
 
-    def now_minus_one_day(self) -> datetime:
-        return self.now() - timedelta(days=1)
-
-    def now_minus_20_hours(self) -> datetime:
-        return self.now() - timedelta(hours=20)
-
-    def now_minus_25_hours(self) -> datetime:
-        return self.now() - timedelta(hours=25)
-
-    def now_minus_two_days(self) -> datetime:
-        return self.now() - timedelta(days=2)
-
-    def now_minus_ten_days(self) -> datetime:
-        return self.now() - timedelta(days=10)
-
-    def now_plus_one_day(self) -> datetime:
-        return self.now() + timedelta(days=1)
+    def now_minus(self, delta: timedelta) -> datetime:
+        return self.now() - delta

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -7,6 +7,12 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.injector import singleton
 
 
+def datetime_utc(
+    year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0
+) -> datetime:
+    return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
+
+
 @singleton
 class FakeDatetimeService(DatetimeService):
     def __init__(self) -> None:

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 from dateutil import tz
@@ -13,7 +13,7 @@ class FakeDatetimeService(DatetimeService):
         self.frozen_time: Optional[datetime] = None
 
     def freeze_time(self, timestamp: Optional[datetime] = None) -> None:
-        self.frozen_time = timestamp if timestamp else datetime.min
+        self.frozen_time = timestamp if timestamp else datetime.min.replace(tzinfo=UTC)
 
     def unfreeze_time(self) -> None:
         self.frozen_time = None
@@ -28,7 +28,9 @@ class FakeDatetimeService(DatetimeService):
         return self.frozen_time
 
     def now(self) -> datetime:
-        return self.frozen_time if self.frozen_time else datetime.now()
+        if self.frozen_time:
+            return self.frozen_time
+        return datetime.now(UTC)
 
     def format_datetime(
         self,
@@ -37,7 +39,7 @@ class FakeDatetimeService(DatetimeService):
         fmt: Optional[str] = None,
     ) -> str:
         if date.tzinfo is None:
-            date = date.replace(tzinfo=timezone.utc)
+            date = date.replace(tzinfo=UTC)
         if zone is not None:
             date = date.astimezone(tz.gettz(zone))
         if fmt is None:

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Optional
 
 import pytz
@@ -30,13 +30,6 @@ class FakeDatetimeService(DatetimeService):
 
     def now(self) -> datetime:
         return self.frozen_time if self.frozen_time else datetime.now()
-
-    def today(self) -> date:
-        return (
-            date(self.frozen_time.year, self.frozen_time.month, self.frozen_time.day)
-            if self.frozen_time
-            else date.today()
-        )
 
     def format_datetime(
         self,

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -13,6 +13,10 @@ def datetime_utc(
     return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
 
 
+def datetime_min_utc() -> datetime:
+    return datetime.min.replace(tzinfo=UTC)
+
+
 @singleton
 class FakeDatetimeService(DatetimeService):
     def __init__(self) -> None:

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-import pytz
 from dateutil import tz
 
 from arbeitszeit.datetime_service import DatetimeService
@@ -38,7 +37,7 @@ class FakeDatetimeService(DatetimeService):
         fmt: Optional[str] = None,
     ) -> str:
         if date.tzinfo is None:
-            date = date.replace(tzinfo=pytz.UTC)
+            date = date.replace(tzinfo=timezone.utc)
         if zone is not None:
             date = date.astimezone(tz.gettz(zone))
         if fmt is None:

--- a/tests/email_presenters/test_accountant_invitation_presenter.py
+++ b/tests/email_presenters/test_accountant_invitation_presenter.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from typing import Callable
 
 from arbeitszeit_web.email.accountant_invitation_presenter import (
     AccountantInvitationEmailPresenter,
     ViewModel,
 )
+from tests.datetime_service import datetime_utc
 from tests.email import FakeEmailConfiguration
 from tests.www.base_test_case import BaseTestCase
 
@@ -41,7 +41,7 @@ class PresenterTests(BaseTestCase):
         )
 
     def test_that_invitation_link_is_correct(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         expected_token = self.token_service.generate_token("test@test.test")
         self.presenter.send_accountant_invitation(email="test@test.test")
         self.assertViewModel(

--- a/tests/email_presenters/test_email_change_confirmation_presenter.py
+++ b/tests/email_presenters/test_email_change_confirmation_presenter.py
@@ -1,11 +1,10 @@
-from datetime import datetime
-
 from parameterized import parameterized
 
 from arbeitszeit import email_notifications
 from arbeitszeit_web.email.email_change_confirmation_presenter import (
     EmailChangeConfirmationPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.email import FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.www.base_test_case import BaseTestCase
@@ -43,7 +42,7 @@ class EmailChangeConfirmationPresenterTests(BaseTestCase):
     def test_that_the_content_of_the_mail_is_rendered_correctly(self) -> None:
         old_email = "test@test.test"
         new_email = "new@test.test"
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         self.presenter.present_email_change_confirmation(
             self.create_email_change_confirmation(
                 new_email_address=new_email,

--- a/tests/email_presenters/test_registration_email_presenter.py
+++ b/tests/email_presenters/test_registration_email_presenter.py
@@ -1,8 +1,7 @@
-from datetime import datetime
-
 from arbeitszeit_web.email.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.email import Email, FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.www.base_test_case import BaseTestCase
@@ -37,7 +36,7 @@ class MemberPresenterTests(BaseTestCase):
         self.assertEqual(self.email_address, recipient)
 
     def test_that_correct_message_is_rendered(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token(self.email_address)
         expected_url = self.url_index.get_member_confirmation_url(token=token)
         self.presenter.show_member_registration_message(self.email_address)
@@ -87,7 +86,7 @@ class CompanyPresenterTests(BaseTestCase):
         self.assertEqual(self.email_address, recipient)
 
     def test_that_correct_message_is_rendered(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token(self.email_address)
         expected_url = self.url_index.get_company_confirmation_url(token=token)
         self.presenter.show_company_registration_message(self.email_address)

--- a/tests/entities/test_plan.py
+++ b/tests/entities/test_plan.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 from decimal import Decimal
 from unittest import TestCase
 
 from arbeitszeit.records import ProductionCosts
 from tests.data_generators import PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 from tests.use_cases.dependency_injection import get_dependency_injector
 
 
@@ -45,21 +44,21 @@ class TestPlanExpirationDate(TestCase):
     def test_that_expiration_date_is_correctly_calculated_if_plan_expires_now(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan_record(
             timeframe=1,
             approved=True,
         )
-        expected_expiration_time = datetime(2000, 1, 2)
+        expected_expiration_time = datetime_utc(2000, 1, 2)
         assert plan.expiration_date == expected_expiration_time
 
     def test_that_expiration_date_is_correctly_calculated_if_plan_expires_in_the_future(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan_record(
             timeframe=2,
             approved=True,
         )
-        expected_expiration_time = datetime(2000, 1, 3)
+        expected_expiration_time = datetime_utc(2000, 1, 3)
         assert plan.expiration_date == expected_expiration_time

--- a/tests/flask_integration/database_gateway_impl/test_account_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_result.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID, uuid4
@@ -7,6 +6,7 @@ from parameterized import parameterized
 
 from arbeitszeit import records
 from arbeitszeit.records import SocialAccounting
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 
@@ -35,7 +35,7 @@ class AccountResultTests(FlaskTestCase):
             account_credentials=credentials.id,
             name="test name",
             account=account,
-            registered_on=datetime(2000, 1, 1),
+            registered_on=datetime_utc(2000, 1, 1),
         )
         result = (
             self.database_gateway.get_accounts()
@@ -208,7 +208,7 @@ class AccountResultTests(FlaskTestCase):
             labour_account=labour_account or self.database_gateway.create_account(),
             resource_account=resource_account or self.database_gateway.create_account(),
             products_account=products_account or self.database_gateway.create_account(),
-            registered_on=datetime(2000, 1, 1),
+            registered_on=datetime_utc(2000, 1, 1),
         )
 
     def create_cooperation(
@@ -216,7 +216,7 @@ class AccountResultTests(FlaskTestCase):
         account: UUID,
     ) -> records.Cooperation:
         return self.database_gateway.create_cooperation(
-            creation_timestamp=datetime(2000, 1, 1),
+            creation_timestamp=datetime_utc(2000, 1, 1),
             name="test cooperation",
             definition="some product definition",
             account=account,

--- a/tests/flask_integration/database_gateway_impl/test_company_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_company_result.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List
 from uuid import UUID, uuid4
 
@@ -42,7 +41,7 @@ class CompanyResultTests(FlaskTestCase):
             labour_account=labour_account,
             resource_account=resource_account,
             products_account=products_account,
-            registered_on=datetime.now(),
+            registered_on=self.datetime_service.now(),
         )
 
 

--- a/tests/flask_integration/database_gateway_impl/test_cooperation_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_cooperation_result.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit.records import Cooperation
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 
@@ -15,7 +16,7 @@ class CooperationResultTests(FlaskTestCase):
         self.database_gateway.create_cooperation(
             name="",
             definition="",
-            creation_timestamp=datetime(2000, 1, 1),
+            creation_timestamp=datetime_utc(2000, 1, 1),
             account=self.database_gateway.create_account().id,
         )
         cooperations = self.database_gateway.get_cooperations()
@@ -24,7 +25,7 @@ class CooperationResultTests(FlaskTestCase):
     def test_that_created_cooperation_has_correct_properties_assigned(self) -> None:
         expected_name = "expected_name"
         expected_definition = "expected definition"
-        expected_creation_timestamp = datetime(2345, 1, 12)
+        expected_creation_timestamp = datetime_utc(2345, 1, 12)
         expected_account = self.database_gateway.create_account().id
         cooperation = self.database_gateway.create_cooperation(
             name=expected_name,
@@ -78,7 +79,7 @@ class CooperationResultTests(FlaskTestCase):
         return self.database_gateway.create_cooperation(
             name=name,
             definition="",
-            creation_timestamp=datetime(2000, 1, 1),
+            creation_timestamp=datetime_utc(2000, 1, 1),
             account=self.database_gateway.create_account().id,
         )
 
@@ -87,13 +88,13 @@ class CoordinatedByCompanyTests(FlaskTestCase):
     def test_results_filtered_by_coordinator_includes_previously_created_coop_by_coordinator(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         coordinator = self.company_generator.create_company()
         cooperation = self.cooperation_generator.create_cooperation()
         self.database_gateway.create_coordination_tenure(
             company=coordinator,
             cooperation=cooperation,
-            start_date=datetime(2000, 1, 2),
+            start_date=datetime_utc(2000, 1, 2),
         )
         cooperations = self.database_gateway.get_cooperations()
         assert cooperations.coordinated_by_company(coordinator)
@@ -101,11 +102,11 @@ class CoordinatedByCompanyTests(FlaskTestCase):
     def test_with_two_cooperations_with_two_tenures_each_by_the_same_coordinator_we_receive_two_results(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         coordinator = self.company_generator.create_company()
         coop_1 = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         coop_2 = self.cooperation_generator.create_cooperation(coordinator=coordinator)
-        tenure_start_date = datetime(2000, 1, 2)
+        tenure_start_date = datetime_utc(2000, 1, 2)
         self.database_gateway.create_coordination_tenure(
             company=coordinator, cooperation=coop_1, start_date=tenure_start_date
         )
@@ -130,7 +131,7 @@ class CoordinatedByCompanyTests(FlaskTestCase):
         self.database_gateway.create_coordination_tenure(
             company=coordinator,
             cooperation=cooperation,
-            start_date=datetime(2000, 1, 1),
+            start_date=datetime_utc(2000, 1, 1),
         )
         cooperations = self.database_gateway.get_cooperations()
         assert not cooperations.coordinated_by_company(other_company)
@@ -167,7 +168,7 @@ class JoinedWithCurrentCoordinatorTests(FlaskTestCase):
         coordinator_id = self.company_generator.create_company(
             name=expected_coordinator_name
         )
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         coop = self.cooperation_generator.create_cooperation(coordinator=coordinator_id)
         self.datetime_service.advance_time(timedelta(days=1))
         expected_coordination = self.database_gateway.create_coordination_tenure(
@@ -195,13 +196,13 @@ class JoinedWithCurrentCoordinatorTests(FlaskTestCase):
         )
 
     def test_for_one_cooperation_get_one_result_when_tenure_changed_once(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         new_coordinator = self.company_generator.create_company()
         cooperation = self.cooperation_generator.create_cooperation()
         self.database_gateway.create_coordination_tenure(
             company=new_coordinator,
             cooperation=cooperation,
-            start_date=datetime(2000, 1, 2),
+            start_date=datetime_utc(2000, 1, 2),
         )
         assert (
             len(

--- a/tests/flask_integration/database_gateway_impl/test_coordination_tenure_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_coordination_tenure_result.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 from uuid import UUID
 
 from arbeitszeit.records import CoordinationTenure
+from tests.datetime_service import datetime_utc
 from tests.flask_integration.flask import FlaskTestCase
 
 
@@ -17,7 +18,7 @@ class CoordinationTenureResultTests(FlaskTestCase):
         self.database_gateway.create_coordination_tenure(
             company=self.company_generator.create_company(),
             cooperation=self.cooperation_generator.create_cooperation(),
-            start_date=datetime(2000, 1, 1),
+            start_date=datetime_utc(2000, 1, 1),
         )
         coordination_tenures = self.database_gateway.get_coordination_tenures()
         assert coordination_tenures
@@ -27,7 +28,7 @@ class CoordinationTenureResultTests(FlaskTestCase):
     ) -> None:
         expected_company = self.company_generator.create_company()
         expected_cooperation = self.cooperation_generator.create_cooperation()
-        expected_start_date = datetime(2345, 1, 12)
+        expected_start_date = datetime_utc(2345, 1, 12)
         coordination_tenure = self.database_gateway.create_coordination_tenure(
             company=expected_company,
             cooperation=expected_cooperation,
@@ -57,7 +58,7 @@ class CoordinationTenureResultTests(FlaskTestCase):
     def test_coordinations_can_be_ordered_by_start_date_in_descending_order(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         first_coordination_tenure = self.create_coordination_tenure()
         self.datetime_service.advance_time(dt=timedelta(days=1))
         second_coordination_tenure = self.create_coordination_tenure()
@@ -101,7 +102,7 @@ class CoordinationsOfCooperationTests(FlaskTestCase):
         return self.database_gateway.create_coordination_tenure(
             company=self.company_generator.create_company(),
             cooperation=cooperation,
-            start_date=datetime(2000, 1, 1),
+            start_date=datetime_utc(2000, 1, 1),
         )
 
 
@@ -113,7 +114,7 @@ class JoinedWithCoordinatorTests(FlaskTestCase):
         coordination_tenure = self.database_gateway.create_coordination_tenure(
             company=expected_coordinator,
             cooperation=self.cooperation_generator.create_cooperation(),
-            start_date=datetime(2000, 1, 1),
+            start_date=datetime_utc(2000, 1, 1),
         )
         self.assertTrue(
             self.companyIsCoordinatorOfCoordination(

--- a/tests/flask_integration/database_gateway_impl/test_coordination_transfer_request_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_coordination_transfer_request_result.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 from uuid import UUID
 
 from arbeitszeit.records import CoordinationTransferRequest
+from tests.datetime_service import datetime_utc
 from tests.flask_integration.flask import FlaskTestCase
 
 
@@ -34,7 +34,7 @@ class CoordinationTransferRequestResultTests(FlaskTestCase):
             self.coordination_tenure_generator.create_coordination_tenure()
         )
         expected_candidate = self.company_generator.create_company()
-        expected_request_date = datetime(2020, 5, 1)
+        expected_request_date = datetime_utc(2020, 5, 1)
         result = self.database_gateway.create_coordination_transfer_request(
             requesting_coordination_tenure=expected_requesting_coordination_tenure,
             candidate=expected_candidate,

--- a/tests/flask_integration/database_gateway_impl/test_email_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_email_result.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-
 import pytest
 from sqlalchemy.exc import IntegrityError
+
+from tests.datetime_service import datetime_min_utc
 
 from ..flask import FlaskTestCase
 from .utility import Utility
@@ -14,7 +14,7 @@ class CreateEmailAddressTests(FlaskTestCase):
         self.database_gateway.create_email_address(address=address, confirmed_on=None)
         with pytest.raises(IntegrityError):
             self.database_gateway.create_email_address(
-                address=address, confirmed_on=datetime.min
+                address=address, confirmed_on=datetime_min_utc()
             )
 
     @pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
@@ -24,7 +24,7 @@ class CreateEmailAddressTests(FlaskTestCase):
         altered_address = Utility.mangle_case(address)
         with pytest.raises(IntegrityError):
             self.database_gateway.create_email_address(
-                address=altered_address, confirmed_on=datetime.min
+                address=altered_address, confirmed_on=datetime_min_utc()
             )
 
 

--- a/tests/flask_integration/database_gateway_impl/test_email_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_email_result.py
@@ -1,13 +1,39 @@
+from datetime import UTC, datetime
+
 import pytest
+from dateutil import tz
 from sqlalchemy.exc import IntegrityError
 
-from tests.datetime_service import datetime_min_utc
+from tests.datetime_service import datetime_min_utc, datetime_utc
 
 from ..flask import FlaskTestCase
 from .utility import Utility
 
 
 class CreateEmailAddressTests(FlaskTestCase):
+    def test_created_email_address_contains_utc_confirmation_date(self) -> None:
+        confirmation_date = datetime_utc(2023, 1, 2, 3, 4, 5)
+        self.database_gateway.create_email_address(
+            address="test@test.test",
+            confirmed_on=confirmation_date,
+        )
+        email_address = self.database_gateway.get_email_addresses().first()
+        assert email_address is not None
+        assert email_address.confirmed_on == confirmation_date
+        assert email_address.confirmed_on.tzinfo == UTC
+
+    def test_returned_confirmation_date_gets_time_zone_changed_to_utc(self) -> None:
+        original_date = datetime(2023, 1, 2, 3, 4, 5).astimezone(tz.gettz("Asia/Tokyo"))
+        self.database_gateway.create_email_address(
+            address="test@test.test",
+            confirmed_on=original_date,
+        )
+        email_address = self.database_gateway.get_email_addresses().first()
+        assert email_address is not None
+        assert email_address.confirmed_on == original_date
+        assert email_address.confirmed_on.tzinfo != original_date.tzinfo
+        assert email_address.confirmed_on.tzinfo == UTC
+
     @pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
     def test_cannot_create_same_email_address_twice(self) -> None:
         address = "test@test.test"

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -7,6 +6,7 @@ from parameterized import parameterized
 from sqlalchemy.exc import IntegrityError
 
 from arbeitszeit import records
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 from .utility import Utility
@@ -142,10 +142,10 @@ class GetAllMembersTests(MemberResultTests):
 class ConfirmMemberTests(MemberResultTests):
     def setUp(self) -> None:
         super().setUp()
-        self.timestamp = datetime(2000, 1, 1)
+        self.timestamp = datetime_utc(2000, 1, 1)
 
     def test_that_confirmed_on_gets_updated_for_affected_user(self) -> None:
-        expected_timestamp = datetime(2000, 1, 2)
+        expected_timestamp = datetime_utc(2000, 1, 2)
         email_address = "test@test.test"
         member = self.create_member(email_address=email_address)
         self.database_gateway.get_email_addresses().with_address(

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -160,6 +160,7 @@ class ConfirmMemberTests(MemberResultTests):
         assert record
         _, email = record
         assert email.confirmed_on == expected_timestamp
+        assert email.confirmed_on.tzinfo is not None
 
 
 class CreateMemberTests(MemberResultTests):

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -29,7 +29,7 @@ class MemberResultTests(FlaskTestCase):
         return self.database_gateway.create_member(
             name="karl",
             account=account,
-            registered_on=datetime.now(),
+            registered_on=self.datetime_service.now(),
             account_credentials=credentials,
         )
 

--- a/tests/flask_integration/database_gateway_impl/test_password_reset_request_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_password_reset_request_result.py
@@ -21,7 +21,7 @@ class PasswordResetRequestResultTests(FlaskTestCase):
         email_address = self.email_generator.get_random_email()
         self.database_gateway.create_email_address(
             address=email_address,
-            confirmed_on=self.datetime_service.now_minus_ten_days(),
+            confirmed_on=self.datetime_service.now_minus(timedelta(days=10)),
         )
         return email_address
 

--- a/tests/flask_integration/database_gateway_impl/test_password_reset_request_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_password_reset_request_result.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit import records
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 
@@ -38,7 +39,7 @@ class PasswordResetRequestResultTests(FlaskTestCase):
     def test_querying_password_reset_request_by_email(self) -> None:
         email_address = self._generate_email_address()
         other_email_address = self._generate_email_address()
-        self.datetime_service.freeze_time(datetime(2021, 2, 13, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2021, 2, 13, hour=10))
 
         self._create_password_reset_request(email_address)
         self._create_password_reset_request(other_email_address)
@@ -53,7 +54,7 @@ class PasswordResetRequestResultTests(FlaskTestCase):
 
     def test_multiple_password_reset_requests_can_exist_for_given_email(self) -> None:
         email_address = self._generate_email_address()
-        self.datetime_service.freeze_time(datetime(2021, 2, 13, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2021, 2, 13, hour=10))
 
         self._create_password_reset_request(email_address)
         self._create_password_reset_request(email_address)
@@ -69,7 +70,7 @@ class PasswordResetRequestResultTests(FlaskTestCase):
 
     def test_querying_password_reset_requests_after_datetime_threshold(self) -> None:
         email_address = self._generate_email_address()
-        self.datetime_service.freeze_time(datetime(2021, 2, 13, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2021, 2, 13, hour=10))
 
         self._create_password_reset_request(email_address)
         self.datetime_service.advance_time(timedelta(hours=1))
@@ -93,7 +94,7 @@ class PasswordResetRequestResultTests(FlaskTestCase):
     def test_querying_interleaved_non_spammed_and_spammed_requests(self) -> None:
         spammed_email_address = self._generate_email_address()
         not_spammed_email_address = self._generate_email_address()
-        self.datetime_service.freeze_time(datetime(2021, 2, 13, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2021, 2, 13, hour=10))
 
         self._create_password_reset_request(not_spammed_email_address)
         self.datetime_service.advance_time(timedelta(hours=2))

--- a/tests/flask_integration/database_gateway_impl/test_plan_draft_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_draft_result.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 from parameterized import parameterized
 
 from arbeitszeit.records import PlanDraft, ProductionCosts
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 
@@ -80,7 +81,7 @@ class PlanDraftRepositoryTests(PlanDraftRepositoryBaseTests):
     def test_that_created_draft_has_creation_timestamp_it_was_created_with(
         self,
     ) -> None:
-        expected_timestamp = datetime(2000, 1, 2)
+        expected_timestamp = datetime_utc(2000, 1, 2)
         draft = self.create_plan_draft(creation_timestamp=expected_timestamp)
         assert draft.creation_date == expected_timestamp
 

--- a/tests/flask_integration/database_gateway_impl/test_plan_results.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_results.py
@@ -91,11 +91,11 @@ class GetActivePlansTests(FlaskTestCase):
         self,
     ) -> None:
         creation_dates = [
-            self.datetime_service.now_minus_ten_days(),
+            self.datetime_service.now_minus(timedelta(days=10)),
             self.datetime_service.now(),
-            self.datetime_service.now_minus_20_hours(),
-            self.datetime_service.now_minus_25_hours(),
-            self.datetime_service.now_minus_one_day(),
+            self.datetime_service.now_minus(timedelta(hours=20)),
+            self.datetime_service.now_minus(timedelta(hours=25)),
+            self.datetime_service.now_minus(timedelta(days=1)),
         ]
         plans: List[UUID] = list()
         for timestamp in creation_dates:
@@ -116,11 +116,11 @@ class GetActivePlansTests(FlaskTestCase):
         self,
     ) -> None:
         approval_dates = [
-            self.datetime_service.now_minus_ten_days(),
+            self.datetime_service.now_minus(timedelta(days=10)),
             self.datetime_service.now(),
-            self.datetime_service.now_minus_20_hours(),
-            self.datetime_service.now_minus_25_hours(),
-            self.datetime_service.now_minus_one_day(),
+            self.datetime_service.now_minus(timedelta(hours=20)),
+            self.datetime_service.now_minus(timedelta(hours=25)),
+            self.datetime_service.now_minus(timedelta(days=1)),
         ]
         plans: List[UUID] = list()
         for timestamp in approval_dates:
@@ -141,11 +141,11 @@ class GetActivePlansTests(FlaskTestCase):
         self,
     ) -> None:
         rejection_dates = [
-            self.datetime_service.now_minus_ten_days(),
+            self.datetime_service.now_minus(timedelta(days=10)),
             self.datetime_service.now(),
-            self.datetime_service.now_minus_20_hours(),
-            self.datetime_service.now_minus_25_hours(),
-            self.datetime_service.now_minus_one_day(),
+            self.datetime_service.now_minus(timedelta(hours=20)),
+            self.datetime_service.now_minus(timedelta(hours=25)),
+            self.datetime_service.now_minus(timedelta(days=1)),
         ]
         plans: List[UUID] = list()
         for timestamp in rejection_dates:

--- a/tests/flask_integration/database_gateway_impl/test_plan_results.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_results.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import UTC, timedelta
 from decimal import Decimal
 from typing import List
 from uuid import UUID, uuid4
@@ -38,6 +38,7 @@ class PlanResultTests(FlaskTestCase):
             is_public_service=(expected_is_public_service := False),
         )
         assert plan.plan_creation_date == expected_timestamp
+        assert plan.plan_creation_date.tzinfo == UTC
         assert plan.planner == expected_planner
         assert plan.production_costs == expected_costs
         assert plan.prd_name == expected_product_name

--- a/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from tests.control_thresholds import ControlThresholdsTestImpl
+from tests.datetime_service import datetime_utc
 from tests.flask_integration.flask import FlaskTestCase
 
 
@@ -68,7 +69,7 @@ class PrivateConsumptionTests(FlaskTestCase):
         assert not consumptions.where_consumer_is_member(other_member)
 
     def test_that_plans_can_be_ordered_by_creation_date(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan_1 = self.plan_generator.create_plan()
         self.consumption_generator.create_private_consumption(plan=plan_1)
         self.datetime_service.advance_time(timedelta(days=1))

--- a/tests/flask_integration/database_gateway_impl/test_productive_consumption_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_productive_consumption_result.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
 from arbeitszeit.records import ProductionCosts
+from tests.datetime_service import datetime_utc
 from tests.flask_integration.flask import FlaskTestCase
 
 
@@ -82,7 +83,7 @@ class ProductiveConsumptionResultTests(FlaskTestCase):
         assert not consumptions.where_consumer_is_company(other_company)
 
     def test_that_plans_can_be_ordered_by_creation_date(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan_1 = self.plan_generator.create_plan()
         self.consumption_generator.create_resource_consumption_by_company(plan=plan_1)
         self.datetime_service.advance_time(timedelta(days=1))

--- a/tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 from parameterized import parameterized
 
 from arbeitszeit.use_cases import register_hours_worked
+from tests.datetime_service import datetime_utc
 
 from ..flask import FlaskTestCase
 
@@ -63,9 +64,9 @@ class RegisteredHoursWorkedResultTests(FlaskTestCase):
 
     @parameterized.expand(
         [
-            datetime(2000, 1, 1),
-            datetime(2000, 1, 2),
-            datetime(2012, 3, 21),
+            datetime_utc(2000, 1, 1),
+            datetime_utc(2000, 1, 2),
+            datetime_utc(2012, 3, 21),
         ]
     )
     def test_that_record_has_specified_registration_time(

--- a/tests/flask_integration/database_gateway_impl/test_transfer_query_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_transfer_query_result.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from uuid import uuid4
 
 from parameterized import parameterized
@@ -6,6 +5,7 @@ from sqlalchemy import text
 
 from arbeitszeit.records import AccountTypes, SocialAccounting
 from arbeitszeit.transfers.transfer_type import TransferType
+from tests.datetime_service import datetime_utc
 from tests.flask_integration.flask import FlaskTestCase
 
 
@@ -271,8 +271,8 @@ class OrderedByDateTests(FlaskTestCase):
     def test_that_transfers_can_be_ordered_in_ascending_or_descending_order(
         self, ascending: bool
     ) -> None:
-        date1 = datetime(2021, 1, 1)
-        date2 = datetime(2021, 1, 2)
+        date1 = datetime_utc(2021, 1, 1)
+        date2 = datetime_utc(2021, 1, 2)
         self.datetime_service.freeze_time(date1)
         self.transfer_generator.create_transfer()
         self.datetime_service.freeze_time(date2)

--- a/tests/services/test_compensation_transfer_service.py
+++ b/tests/services/test_compensation_transfer_service.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -7,6 +6,7 @@ from parameterized import parameterized
 from arbeitszeit.records import Transfer
 from arbeitszeit.transfers.compensation import CompensationTransferService
 from arbeitszeit.transfers.transfer_type import TransferType
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -42,7 +42,7 @@ class CompensationTransferServiceTests(BaseTestCase):
         consumed_amount: int,
     ) -> None:
         EXPECTED_TYPE = TransferType.compensation_for_coop
-        EXPECTED_TIME = datetime(2025, 1, 1, 10, 15)
+        EXPECTED_TIME = datetime_utc(2025, 1, 1, 10, 15)
         EXPECTED_DEBIT_ACCOUNT = self.database_gateway.create_account().id
         EXPECTED_CREDIT_ACCOUNT = self.database_gateway.create_account().id
         EXPECTED_VALUE = (
@@ -79,7 +79,7 @@ class CompensationTransferServiceTests(BaseTestCase):
         consumed_amount: int,
     ) -> None:
         EXPECTED_TYPE = TransferType.compensation_for_company
-        EXPECTED_TIME = datetime(2025, 1, 1, 10, 15)
+        EXPECTED_TIME = datetime_utc(2025, 1, 1, 10, 15)
         EXPECTED_DEBIT_ACCOUNT = self.database_gateway.create_account().id
         EXPECTED_CREDIT_ACCOUNT = self.database_gateway.create_account().id
         EXPECTED_VALUE = (

--- a/tests/services/test_payout_factor_service.py
+++ b/tests/services/test_payout_factor_service.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 
 from arbeitszeit.payout_factor import PayoutFactorService
 from arbeitszeit.records import ProductionCosts
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -98,7 +99,7 @@ class PayoutFactorServiceCalculationTests(BaseTestCase):
     def test_that_payout_factor_gets_calculated_based_on_supplied_timestamp(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         self.plan_generator.create_plan(
             is_public_service=False,
             costs=ProductionCosts(
@@ -118,5 +119,9 @@ class PayoutFactorServiceCalculationTests(BaseTestCase):
             ),
             timeframe=10,
         )
-        assert self.service.calculate_payout_factor(datetime(2000, 1, 2)) == Decimal(1)
-        assert self.service.calculate_payout_factor(datetime(2000, 1, 6)) == Decimal(0)
+        assert self.service.calculate_payout_factor(
+            datetime_utc(2000, 1, 2)
+        ) == Decimal(1)
+        assert self.service.calculate_payout_factor(
+            datetime_utc(2000, 1, 6)
+        ) == Decimal(0)

--- a/tests/services/test_plan_details_service.py
+++ b/tests/services/test_plan_details_service.py
@@ -9,7 +9,7 @@ from arbeitszeit.plan_details import PlanDetails, PlanDetailsService
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.approve_plan import ApprovePlanUseCase
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 from tests.use_cases.dependency_injection import get_dependency_injector
 
 
@@ -197,9 +197,9 @@ class PlanDetailsServiceTests(TestCase):
     def test_that_one_active_days_is_shown_if_plan_is_active_since_25_hours(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan()
-        self.datetime_service.freeze_time(datetime(2000, 1, 2, hour=1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 2, hour=1))
         details = self.service.get_details_from_plan(plan)
         assert details
         self.assertEqual(details.active_days, 1)
@@ -208,19 +208,19 @@ class PlanDetailsServiceTests(TestCase):
         self,
     ) -> None:
         timeframe = 7
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan(
             timeframe=timeframe,
         )
-        self.datetime_service.freeze_time(datetime(2000, 1, 11))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 11))
         details = self.service.get_details_from_plan(plan)
         assert details
         self.assertEqual(details.active_days, timeframe)
 
     @parameterized.expand(
         [
-            (datetime(2000, 1, 1), timedelta(days=1)),
-            (datetime(2001, 2, 2), timedelta(hours=1)),
+            (datetime_utc(2000, 1, 1), timedelta(days=1)),
+            (datetime_utc(2001, 2, 2), timedelta(hours=1)),
         ]
     )
     def test_that_creation_date_is_shown(
@@ -235,8 +235,8 @@ class PlanDetailsServiceTests(TestCase):
 
     @parameterized.expand(
         [
-            (datetime(2000, 1, 1), timedelta(days=1), timedelta(days=1)),
-            (datetime(2001, 2, 2), timedelta(hours=1), timedelta(days=2)),
+            (datetime_utc(2000, 1, 1), timedelta(days=1), timedelta(days=1)),
+            (datetime_utc(2001, 2, 2), timedelta(hours=1), timedelta(days=2)),
         ]
     )
     def test_that_approval_date_is_shown_if_it_exists(

--- a/tests/use_cases/get_company_summary/test_expectations.py
+++ b/tests/use_cases/get_company_summary/test_expectations.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.get_company_summary import GetCompanySummary
+from tests.datetime_service import datetime_utc
 
 from ..base_test_case import BaseTestCase
 
@@ -56,7 +57,7 @@ class ExpectationsTestCase(BaseTestCase):
     def test_that_expectations_for_a_are_exactly_planned_labour_after_approved_plan_expired(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         company = self.company_generator.create_company()
         expected_a = Decimal(1231)
         self.plan_generator.create_plan(
@@ -96,7 +97,7 @@ class ExpectationsTestCase(BaseTestCase):
         self,
     ) -> None:
         expected_prd = Decimal(12 * 3)
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         company = self.company_generator.create_company()
         self.plan_generator.create_plan(
             costs=ProductionCosts(

--- a/tests/use_cases/get_company_summary/test_get_company_summary.py
+++ b/tests/use_cases/get_company_summary/test_get_company_summary.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import uuid4
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.get_company_summary import GetCompanySummary
+from tests.datetime_service import datetime_utc
 
 from ..base_test_case import BaseTestCase
 
@@ -36,10 +37,10 @@ class UseCaseTests(BaseTestCase):
         assert response.email == "company@cp.org"
 
     def test_returns_register_date(self) -> None:
-        expected_registration_date = datetime(2022, 1, 25)
+        expected_registration_date = datetime_utc(2022, 1, 25)
         self.datetime_service.freeze_time(expected_registration_date)
         company = self.company_generator.create_company()
-        self.datetime_service.freeze_time(datetime(2022, 1, 26))
+        self.datetime_service.freeze_time(datetime_utc(2022, 1, 26))
         response = self.get_company_summary(company)
         assert response
         assert response.registered_on == expected_registration_date
@@ -58,7 +59,7 @@ class UseCaseTests(BaseTestCase):
     def test_labour_account_shows_planned_labour_certs_after_plan_expired_and_no_workers_were_paid(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 2, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 2, 1))
         expected_amount = Decimal(12)
         company = self.company_generator.create_company()
         self.plan_generator.create_plan(
@@ -91,7 +92,7 @@ class UseCaseTests(BaseTestCase):
 
     def test_returns_list_of_companys_plans_in_descending_order(self) -> None:
         company = self.company_generator.create_company()
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         third = self.plan_generator.create_plan(planner=company)
         self.datetime_service.freeze_time(
             self.datetime_service.now() - timedelta(days=9)
@@ -101,7 +102,7 @@ class UseCaseTests(BaseTestCase):
             self.datetime_service.now() + timedelta(days=8)
         )
         second = self.plan_generator.create_plan(planner=company)
-        self.datetime_service.freeze_time(datetime(2000, 1, 2))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 2))
         response = self.get_company_summary(company)
         assert response
         assert response.plan_details[0].id == third

--- a/tests/use_cases/test_accept_cooperation.py
+++ b/tests/use_cases/test_accept_cooperation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases.accept_cooperation import (
     AcceptCooperationRequest,
 )
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -202,7 +203,7 @@ class AcceptCooperationTests(BaseTestCase):
         assert response.is_rejected
 
     def test_that_cooperation_cannot_be_accepted_for_expired_plans(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         requester = self.company_generator.create_company()
         cooperation = self.cooperation_generator.create_cooperation(
             coordinator=requester

--- a/tests/use_cases/test_approve_plan.py
+++ b/tests/use_cases/test_approve_plan.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import UUID
 
@@ -19,6 +18,7 @@ from arbeitszeit.use_cases.register_productive_consumption import (
     RegisterProductiveConsumption,
     RegisterProductiveConsumptionRequest,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -51,7 +51,7 @@ class UseCaseTests(BaseTestCase):
         assert self.get_latest_activated_plan().plan_id == plan
 
     def test_that_approval_date_is_set_correctly(self) -> None:
-        expected_approval_timestamp = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        expected_approval_timestamp = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(expected_approval_timestamp)
         plan = self.plan_generator.create_plan(approved=False)
         response = self.use_case.approve_plan(self.create_request(plan=plan))
@@ -192,7 +192,7 @@ class UseCaseTests(BaseTestCase):
                 means_cost=planned_p_amount,
             ),
         )
-        approval_time = datetime(2000, 1, 1)
+        approval_time = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(approval_time)
         self.use_case.approve_plan(self.create_request(plan=plan))
         self.datetime_service.unfreeze_time()
@@ -242,7 +242,7 @@ class UseCaseTests(BaseTestCase):
                 means_cost=Decimal(1),
             ),
         )
-        approval_time = datetime(2000, 1, 1)
+        approval_time = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(approval_time)
         self.use_case.approve_plan(self.create_request(plan=plan))
         self.datetime_service.unfreeze_time()
@@ -292,7 +292,7 @@ class UseCaseTests(BaseTestCase):
                 means_cost=Decimal(1),
             ),
         )
-        approval_time = datetime(2000, 1, 1)
+        approval_time = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(approval_time)
         self.use_case.approve_plan(self.create_request(plan=plan))
         self.datetime_service.unfreeze_time()
@@ -322,7 +322,7 @@ class UseCaseTests(BaseTestCase):
             approved=False,
             is_public_service=is_public_service,
         )
-        approval_time = datetime(2000, 1, 1)
+        approval_time = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(approval_time)
         self.use_case.approve_plan(self.create_request(plan=plan))
         self.datetime_service.unfreeze_time()

--- a/tests/use_cases/test_create_draft_from_plan.py
+++ b/tests/use_cases/test_create_draft_from_plan.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from arbeitszeit import records
 from arbeitszeit.use_cases import create_draft_from_plan as use_case
 from arbeitszeit.use_cases import get_draft_details, show_my_plans
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -186,7 +187,7 @@ class CreateDraftFromPlanTests(BaseTestCase):
         summary = self.create_draft_and_get_details(plan)
         assert summary.is_public_service == expected_is_public
 
-    @parameterized.expand([(datetime(2000, 1, 1),), (datetime(2001, 2, 3),)])
+    @parameterized.expand([(datetime_utc(2000, 1, 1),), (datetime_utc(2001, 2, 3),)])
     def test_that_creating_timestamp_of_draft_is_the_time_of_request(
         self, expected_timestamp: datetime
     ) -> None:

--- a/tests/use_cases/test_deny_cooperation.py
+++ b/tests/use_cases/test_deny_cooperation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit.use_cases.deny_cooperation import (
@@ -10,6 +10,7 @@ from arbeitszeit.use_cases.request_cooperation import (
     RequestCooperation,
     RequestCooperationRequest,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -112,7 +113,7 @@ class UseCaseTests(BaseTestCase):
         self.request_cooperation(request_request)
 
     def test_that_cooperation_for_inactive_plans_cannot_be_denied(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         requester = self.company_generator.create_company()
         cooperation = self.cooperation_generator.create_cooperation(
             coordinator=requester

--- a/tests/use_cases/test_get_company_dashboard.py
+++ b/tests/use_cases/test_get_company_dashboard.py
@@ -1,10 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import TestCase
 from uuid import uuid4
 
 from arbeitszeit.use_cases.get_company_dashboard import GetCompanyDashboardUseCase
 from tests.data_generators import CompanyGenerator, MemberGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 from tests.use_cases.dependency_injection import get_dependency_injector
 
 
@@ -95,7 +95,7 @@ class ThreeLatestPlansTests(TestCase):
     def test_that_approval_date_of_latest_plan_is_set_correctly(
         self,
     ) -> None:
-        expected_datetime = datetime(2020, 10, 10)
+        expected_datetime = datetime_utc(2020, 10, 10)
         self.datetime_service.freeze_time(expected_datetime)
         self.plan_generator.create_plan()
         self.datetime_service.advance_time(timedelta(hours=1))

--- a/tests/use_cases/test_get_coop_summary.py
+++ b/tests/use_cases/test_get_coop_summary.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from typing import Callable, Optional
 from uuid import uuid4
@@ -11,6 +11,7 @@ from arbeitszeit.use_cases.get_coop_summary import (
     GetCoopSummaryRequest,
     GetCoopSummaryResponse,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -87,7 +88,7 @@ class GetCoopSummaryTests(BaseTestCase):
 
     def test_that_inactive_plans_do_not_show_up_in_cooperation_summary(self) -> None:
         requester = self.company_generator.create_company()
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan(timeframe=1)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
         self.datetime_service.advance_time(timedelta(days=2))

--- a/tests/use_cases/test_get_coordination_transfer_request_details.py
+++ b/tests/use_cases/test_get_coordination_transfer_request_details.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -8,6 +7,7 @@ from arbeitszeit.use_cases.accept_coordination_transfer import (
 from arbeitszeit.use_cases.get_coordination_transfer_request_details import (
     GetCoordinationTransferRequestDetailsUseCase as UseCase,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -32,7 +32,7 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         cooperation = self.cooperation_generator.create_cooperation(
             coordinator=coordinator
         )
-        expected_date = datetime(2020, 1, 4)
+        expected_date = datetime_utc(2020, 1, 4)
         self.datetime_service.freeze_time(expected_date)
         response = self.use_case.get_details(
             self.use_case_request(requester=requester, cooperation=cooperation)

--- a/tests/use_cases/test_get_draft_details.py
+++ b/tests/use_cases/test_get_draft_details.py
@@ -12,6 +12,7 @@ from arbeitszeit.use_cases.get_draft_details import (
     GetDraftDetails,
 )
 from tests.data_generators import CompanyGenerator, PlanGenerator
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 from .dependency_injection import injection_test
@@ -118,8 +119,8 @@ class GetDraftDetailsTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            (datetime(2000, 1, 2),),
-            (datetime(2039, 1, 3),),
+            (datetime_utc(2000, 1, 2),),
+            (datetime_utc(2039, 1, 3),),
         ]
     )
     def test_that_creation_timestamp_is_time_of_request_1(

--- a/tests/use_cases/test_get_user_account_details.py
+++ b/tests/use_cases/test_get_user_account_details.py
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases import (
     confirm_member,
     get_user_account_details,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -80,8 +81,8 @@ class GetUserAccountDetailsTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            datetime(2000, 1, 1),
-            datetime(2000, 1, 2),
+            datetime_utc(2000, 1, 1),
+            datetime_utc(2000, 1, 2),
         ]
     )
     def test_that_confirmation_timestamp_for_member_is_the_time_when_their_account_was_confirmed(
@@ -105,8 +106,8 @@ class GetUserAccountDetailsTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            datetime(2000, 1, 1),
-            datetime(2000, 1, 2),
+            datetime_utc(2000, 1, 1),
+            datetime_utc(2000, 1, 2),
         ]
     )
     def test_that_confirmation_timestamp_for_company_is_the_time_when_their_account_was_confirmed(

--- a/tests/use_cases/test_hide_plan.py
+++ b/tests/use_cases/test_hide_plan.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from uuid import UUID
 
 from arbeitszeit.use_cases.hide_plan import HidePlan
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -12,7 +12,7 @@ class UseCaseTests(BaseTestCase):
         super().setUp()
         self.hide_plan = self.injector.get(HidePlan)
         self.show_my_plans_use_case = self.injector.get(ShowMyPlansUseCase)
-        self.now = datetime(2000, 1, 1)
+        self.now = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(self.now)
 
     def test_that_correct_plan_gets_hidden_attribute_set_to_true(self) -> None:
@@ -42,7 +42,7 @@ class UseCaseTests(BaseTestCase):
     def create_expired_plan(self, planner: UUID | None = None) -> UUID:
         if not planner:
             planner = self.company_generator.create_company()
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan(planner=planner, timeframe=1)
         self.datetime_service.unfreeze_time()
         return plan

--- a/tests/use_cases/test_list_all_cooperations.py
+++ b/tests/use_cases/test_list_all_cooperations.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import UUID
 
 from arbeitszeit.use_cases.list_all_cooperations import (
@@ -6,7 +6,7 @@ from arbeitszeit.use_cases.list_all_cooperations import (
     ListAllCooperationsResponse,
 )
 from tests.data_generators import CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 
 from .dependency_injection import injection_test
 
@@ -74,7 +74,7 @@ def test_that_expired_plans_are_not_included_in_plan_count(
     plan_generator: PlanGenerator,
     datetime_service: FakeDatetimeService,
 ) -> None:
-    datetime_service.freeze_time(datetime(2000, 1, 1))
+    datetime_service.freeze_time(datetime_utc(2000, 1, 1))
     plan = plan_generator.create_plan(timeframe=1)
     cooperation_generator.create_cooperation(plans=[plan])
     datetime_service.advance_time(timedelta(days=2))

--- a/tests/use_cases/test_list_coordinations_of_company.py
+++ b/tests/use_cases/test_list_coordinations_of_company.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit.use_cases.list_coordinations_of_company import (
@@ -6,7 +6,7 @@ from arbeitszeit.use_cases.list_coordinations_of_company import (
     ListCoordinationsOfCompanyRequest,
 )
 from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 
 from .dependency_injection import injection_test
 
@@ -92,7 +92,7 @@ def test_that_expired_plans_are_not_counted_in_cooperations(
     cooperation_generator: CooperationGenerator,
     datetime_service: FakeDatetimeService,
 ) -> None:
-    datetime_service.freeze_time(datetime(2000, 1, 1))
+    datetime_service.freeze_time(datetime_utc(2000, 1, 1))
     coordinator = company_generator.create_company_record()
     p1 = plan_generator.create_plan(timeframe=1)
     p2 = plan_generator.create_plan(timeframe=5)

--- a/tests/use_cases/test_list_coordinations_of_cooperation.py
+++ b/tests/use_cases/test_list_coordinations_of_cooperation.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.list_coordinations_of_cooperation import (
     ListCoordinationsOfCooperationUseCase,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -72,7 +73,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
     def test_that_coordination_info_shows_correct_start_time_of_coordination_tenure(
         self,
     ) -> None:
-        expected_time = datetime(2021, 10, 5, 10)
+        expected_time = datetime_utc(2021, 10, 5, 10)
         self.datetime_service.freeze_time(expected_time)
         coop = self.cooperation_generator.create_cooperation()
         self.datetime_service.advance_time(timedelta(days=2))
@@ -84,7 +85,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
     def test_that_coordination_has_no_end_time_when_there_is_only_one_coordination(
         self,
     ) -> None:
-        expected_time = datetime(2021, 10, 5, 10)
+        expected_time = datetime_utc(2021, 10, 5, 10)
         self.datetime_service.freeze_time(expected_time)
         coop = self.cooperation_generator.create_cooperation()
         self.datetime_service.advance_time(timedelta(days=2))
@@ -108,7 +109,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
     def test_that_second_coordination_of_two_in_response_has_correct_end_time(
         self,
     ) -> None:
-        first_timestamp = datetime(2021, 10, 5, 10)
+        first_timestamp = datetime_utc(2021, 10, 5, 10)
         self.datetime_service.freeze_time(first_timestamp)
         coop = self.cooperation_generator.create_cooperation()
         self.datetime_service.advance_time(timedelta(days=2))

--- a/tests/use_cases/test_list_registered_hours_worked.py
+++ b/tests/use_cases/test_list_registered_hours_worked.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
 from parameterized import parameterized
 
 from arbeitszeit.use_cases import list_registered_hours_worked, register_hours_worked
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -116,7 +116,7 @@ class ListRegisteredHoursWorkedTests(BaseTestCase):
         assert response.registered_hours_worked[0].worker_name == EXPECTED_WORKER_NAME
 
     def test_response_includes_registration_timestamp(self) -> None:
-        EXPECTED_DATE = datetime(2024, 5, 1)
+        EXPECTED_DATE = datetime_utc(2024, 5, 1)
         worker_id = self.member_generator.create_member()
         company_id = self.company_generator.create_company(workers=[worker_id])
         self.datetime_service.freeze_time(EXPECTED_DATE)

--- a/tests/use_cases/test_list_transfers.py
+++ b/tests/use_cases/test_list_transfers.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from enum import Enum, auto
 from typing import Optional
@@ -14,6 +13,7 @@ from arbeitszeit.use_cases.list_transfers import (
     Request,
     Response,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -150,7 +150,7 @@ class ListTransfersOfApprovedProductivePlanTests(TransferTestBase):
         assert response.total_results == 6
 
     def test_that_all_transfers_have_correct_date(self) -> None:
-        expected_date = datetime(2024, 1, 1, 12, 0)
+        expected_date = datetime_utc(2024, 1, 1, 12, 0)
         self.datetime_service.freeze_time(expected_date)
         self.plan_generator.create_plan()
         response = self.list_transfers()
@@ -280,11 +280,11 @@ class ListTransfersOfApprovedProductivePlanTests(TransferTestBase):
         )
 
     def test_that_newest_transfer_is_returned_first(self) -> None:
-        date1 = datetime(2024, 1, 1, 12, 0)
+        date1 = datetime_utc(2024, 1, 1, 12, 0)
         self.datetime_service.freeze_time(date1)
         self.plan_generator.create_plan()
 
-        date2 = datetime(2024, 1, 2, 12, 0)
+        date2 = datetime_utc(2024, 1, 2, 12, 0)
         self.datetime_service.freeze_time(date2)
         self.plan_generator.create_plan()
 

--- a/tests/use_cases/test_query_company_consumptions.py
+++ b/tests/use_cases/test_query_company_consumptions.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from arbeitszeit.use_cases.query_company_consumptions import QueryCompanyConsumptions
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -32,7 +33,7 @@ class UseCaseTests(BaseTestCase):
     def test_latter_of_two_consumptions_is_returned_first_other_one_is_returned_second(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         first_plan = self.plan_generator.create_plan()
         second_plan = self.plan_generator.create_plan()
         company = self.company_generator.create_company()

--- a/tests/use_cases/test_query_plans.py
+++ b/tests/use_cases/test_query_plans.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from enum import Enum, auto
 from uuid import UUID, uuid4
@@ -13,6 +13,7 @@ from arbeitszeit.use_cases.query_plans import (
     QueryPlans,
     QueryPlansRequest,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -73,7 +74,7 @@ class UseCaseTests(BaseTestCase):
         search_strategy: SearchStrategy,
     ) -> None:
         expected_number_of_plans = 0
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         for _ in range(3):
             self.plan_generator.create_plan(timeframe=1)
         self.datetime_service.advance_time(timedelta(days=2))
@@ -83,7 +84,7 @@ class UseCaseTests(BaseTestCase):
     def test_that_only_active_plan_is_returned_when_expired_plans_are_excluded(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         self.plan_generator.create_plan(timeframe=1)
         self.datetime_service.advance_time(timedelta(days=2))
         expected_plan = self.plan_generator.create_plan()
@@ -106,7 +107,7 @@ class UseCaseTests(BaseTestCase):
         search_strategy: SearchStrategy,
     ) -> None:
         expected_number_of_plans = 3
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         for _ in range(expected_number_of_plans):
             self.plan_generator.create_plan(timeframe=1)
         self.datetime_service.advance_time(timedelta(days=2))
@@ -116,7 +117,7 @@ class UseCaseTests(BaseTestCase):
     def test_that_expired_plan_is_shown_as_expired(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         self.plan_generator.create_plan(timeframe=1)
         self.datetime_service.advance_time(timedelta(days=2))
         response = self.query_plans(
@@ -207,7 +208,7 @@ class UseCaseTests(BaseTestCase):
         self,
         search_strategy: SearchStrategy,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         expected_third = self.plan_generator.create_plan()
         self.datetime_service.advance_time(timedelta(days=1))
         expected_second = self.plan_generator.create_plan()
@@ -250,7 +251,7 @@ class UseCaseTests(BaseTestCase):
         self,
         search_strategy: SearchStrategy,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 4))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 4))
         expected_second = self.plan_generator.create_plan(product_name="abcde")
         self.datetime_service.advance_time(timedelta(days=1))
         expected_first = self.plan_generator.create_plan(product_name="xyabc")

--- a/tests/use_cases/test_query_private_consumptions.py
+++ b/tests/use_cases/test_query_private_consumptions.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from arbeitszeit.use_cases.query_private_consumptions import (
     QueryPrivateConsumptions,
     Request,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -33,7 +34,7 @@ class TestQueryPrivateConsumptions(BaseTestCase):
         assert response.consumptions[0].plan_id == expected_plan
 
     def test_that_consumptions_are_returned_in_correct_order(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         first_plan = self.plan_generator.create_plan()
         second_plan = self.plan_generator.create_plan()
         member = self.member_generator.create_member()

--- a/tests/use_cases/test_register_private_consumption.py
+++ b/tests/use_cases/test_register_private_consumption.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID, uuid4
@@ -19,6 +18,7 @@ from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionRequest,
     RejectionReason,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -97,11 +97,11 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         )
 
     def test_registration_is_unsuccessful_if_plan_is_expired(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self.plan_generator.create_plan(
             timeframe=1,
         )
-        self.datetime_service.freeze_time(datetime(2001, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2001, 1, 1))
         response = self.register_private_consumption.register_private_consumption(
             self.make_request(plan, amount=3)
         )
@@ -348,7 +348,7 @@ class ConsumptionTransferTests(RegisterPrivateConsumptionBase):
         assert len(transfers) == number_of_consumptions
 
     def test_that_consumption_transfer_has_date_of_consumption(self) -> None:
-        EXPECTED_DATE = datetime(2023, 10, 1, 12, 0, 0)
+        EXPECTED_DATE = datetime_utc(2023, 10, 1, 12, 0, 0)
         self.datetime_service.freeze_time(EXPECTED_DATE)
         self.consumption_generator.create_private_consumption()
         transfers = self.get_private_consumption_transfers()

--- a/tests/use_cases/test_register_productive_consumption.py
+++ b/tests/use_cases/test_register_productive_consumption.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
@@ -15,6 +15,7 @@ from arbeitszeit.use_cases.register_productive_consumption import (
     RegisterProductiveConsumption,
     RegisterProductiveConsumptionRequest,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -50,10 +51,10 @@ class TestRejection(UseCaseBase):
         assert response.rejection_reason == response.RejectionReason.plan_not_found
 
     def test_reject_registration_if_plan_is_expired(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         sender = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(timeframe=1)
-        self.datetime_service.freeze_time(datetime(2001, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2001, 1, 1))
         consumption_type = ConsumptionType.means_of_prod
         pieces = 5
         response = self.register_productive_consumption(
@@ -184,7 +185,7 @@ class TestBalanceChanges(UseCaseBase):
     def test_that_unit_cost_for_cooperating_plans_only_considers_non_expired_plans(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2010, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2010, 1, 1))
         coop = self.cooperation_generator.create_cooperation()
         sender = self.company_generator.create_company()
         self.plan_generator.create_plan(

--- a/tests/use_cases/test_reject_plan.py
+++ b/tests/use_cases/test_reject_plan.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import UUID
 
@@ -15,6 +14,7 @@ from arbeitszeit.use_cases.show_my_plans import (
     ShowMyPlansRequest,
     ShowMyPlansUseCase,
 )
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -42,7 +42,7 @@ class UseCaseTests(BaseTestCase):
         assert not rejection_response.is_plan_rejected
 
     def test_that_rejection_date_is_set_correctly(self) -> None:
-        expected_rejection_timestamp = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        expected_rejection_timestamp = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(expected_rejection_timestamp)
         planner = self.company_generator.create_company_record()
         plan = self.plan_generator.create_plan(

--- a/tests/use_cases/test_request_user_password_reset.py
+++ b/tests/use_cases/test_request_user_password_reset.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from arbeitszeit import email_notifications
 from arbeitszeit.use_cases import request_user_password_reset
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -39,7 +40,7 @@ class RequestUserPasswordResetTest(BaseTestCase):
         self,
     ):
         sent_to_email = "test@email.com"
-        self.datetime_service.freeze_time(datetime(2024, 2, 21, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2024, 2, 21, hour=10))
         for _ in range(request_user_password_reset.Config.max_reset_requests + 1):
             self.use_case.reset_user_password(
                 request_user_password_reset.Request(
@@ -55,7 +56,7 @@ class RequestUserPasswordResetTest(BaseTestCase):
 
     def test_all_reset_password_request_messages_are_sent_over_a_long_time_period(self):
         sent_to_email = "test@email.com"
-        self.datetime_service.freeze_time(datetime(2024, 2, 21, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2024, 2, 21, hour=10))
         total_number_sent_over_threshold = (
             request_user_password_reset.Config.max_reset_requests + 5
         )
@@ -78,7 +79,7 @@ class RequestUserPasswordResetTest(BaseTestCase):
         sent_to_email1 = "test1@email.com"
         sent_to_email2 = "test2@email.com"
         number_of_requests = 3
-        self.datetime_service.freeze_time(datetime(2024, 2, 21, hour=10))
+        self.datetime_service.freeze_time(datetime_utc(2024, 2, 21, hour=10))
         for _ in range(number_of_requests):
             self.use_case.reset_user_password(
                 request_user_password_reset.Request(

--- a/tests/use_cases/test_review_registered_consumptions.py
+++ b/tests/use_cases/test_review_registered_consumptions.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from math import isclose
 
@@ -6,6 +5,7 @@ from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.review_registered_consumptions import (
     ReviewRegisteredConsumptionsUseCase as UseCase,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -97,7 +97,7 @@ class PrivateConsumptionDetailsTests(BaseTestCase):
     def test_private_consumption_shows_date_of_when_consumption_was_registered(
         self,
     ) -> None:
-        expected_date = datetime(2019, 5, 1)
+        expected_date = datetime_utc(2019, 5, 1)
         self.datetime_service.freeze_time(expected_date)
         plan = self.plan_generator.create_plan(planner=self.providing_company)
         self.consumption_generator.create_private_consumption(plan=plan)
@@ -217,7 +217,7 @@ class ProductiveConsumptionDetailsTests(BaseTestCase):
     def test_productive_consumption_shows_date_of_when_consumption_was_registered(
         self,
     ) -> None:
-        expected_date = datetime(2019, 5, 1)
+        expected_date = datetime_utc(2019, 5, 1)
         self.datetime_service.freeze_time(expected_date)
         plan = self.plan_generator.create_plan(planner=self.providing_company)
         self.consumption_generator.create_fixed_means_consumption(plan=plan)

--- a/tests/use_cases/test_show_a_account_details.py
+++ b/tests/use_cases/test_show_a_account_details.py
@@ -13,6 +13,7 @@ from arbeitszeit.use_cases.register_hours_worked import (
     RegisterHoursWorked,
     RegisterHoursWorkedRequest,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -180,11 +181,11 @@ class UseCaseTester(BaseTestCase):
     def test_that_correct_plotting_info_is_generated_after_transferring_of_work_certs_to_two_workers(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         worker1 = self.member_generator.create_member()
         worker2 = self.member_generator.create_member()
         own_company = self.company_generator.create_company(workers=[worker1, worker2])
-        expected_transfer_1_timestamp = datetime(2000, 1, 2)
+        expected_transfer_1_timestamp = datetime_utc(2000, 1, 2)
         self.datetime_service.freeze_time(expected_transfer_1_timestamp)
         self.register_hours_worked(
             RegisterHoursWorkedRequest(
@@ -193,7 +194,7 @@ class UseCaseTester(BaseTestCase):
                 hours_worked=Decimal("10"),
             )
         )
-        expected_transfer_2_timestamp = datetime(2000, 1, 3)
+        expected_transfer_2_timestamp = datetime_utc(2000, 1, 3)
         self.datetime_service.freeze_time(expected_transfer_2_timestamp)
         self.register_hours_worked(
             RegisterHoursWorkedRequest(
@@ -222,7 +223,7 @@ class UseCaseTester(BaseTestCase):
             workers=[worker1, worker2, worker3]
         )
 
-        first_transfer_timestamp = datetime(2000, 1, 1)
+        first_transfer_timestamp = datetime_utc(2000, 1, 1)
         self.datetime_service.freeze_time(first_transfer_timestamp)
         self.register_hours_worked(
             RegisterHoursWorkedRequest(
@@ -231,7 +232,7 @@ class UseCaseTester(BaseTestCase):
                 hours_worked=Decimal("10"),
             )
         )
-        second_transfer_timestamp = datetime(2000, 1, 2)
+        second_transfer_timestamp = datetime_utc(2000, 1, 2)
         self.datetime_service.freeze_time(second_transfer_timestamp)
         self.register_hours_worked(
             RegisterHoursWorkedRequest(
@@ -240,7 +241,7 @@ class UseCaseTester(BaseTestCase):
                 hours_worked=Decimal("10"),
             )
         )
-        third_transfer_timestamp = datetime(2000, 1, 3)
+        third_transfer_timestamp = datetime_utc(2000, 1, 3)
         self.datetime_service.freeze_time(third_transfer_timestamp)
         self.register_hours_worked(
             RegisterHoursWorkedRequest(
@@ -260,7 +261,7 @@ class UseCaseTester(BaseTestCase):
     def test_that_correct_plotting_info_is_generated_after_receiving_of_work_certificates_from_social_accounting(
         self,
     ) -> None:
-        transfer_timestamp = datetime(2030, 1, 1)
+        transfer_timestamp = datetime_utc(2030, 1, 1)
         expected_labour_time = Decimal(123)
         self.datetime_service.freeze_time(transfer_timestamp)
         company = self.company_generator.create_company()

--- a/tests/use_cases/test_show_company_cooperations.py
+++ b/tests/use_cases/test_show_company_cooperations.py
@@ -1,10 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit.use_cases.show_company_cooperations import (
     Request,
     ShowCompanyCooperationsUseCase,
 )
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -45,7 +46,7 @@ class InboundCooperationRequestsTests(BaseTestCase):
     def test_that_requests_for_expired_plans_are_not_shown(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         coordinator = self.company_generator.create_company_record()
         coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         self.plan_generator.create_plan(requested_cooperation=coop, timeframe=1)
@@ -90,7 +91,7 @@ class OutboundCoopRequestsTests(BaseTestCase):
         ]
 
     def test_that_requests_for_expired_plans_are_not_shown(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         requester = self.company_generator.create_company()
         coop = self.cooperation_generator.create_cooperation()
         self.plan_generator.create_plan(

--- a/tests/use_cases/test_show_my_plans.py
+++ b/tests/use_cases/test_show_my_plans.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
+from tests.datetime_service import datetime_utc
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -51,7 +52,7 @@ class UseCaseTests(BaseTestCase):
         self.assertFalse(response.drafts)
 
     def test_that_drafts_are_returned_in_correct_order(self) -> None:
-        creation_time_1 = datetime(2020, 5, 1, 20)
+        creation_time_1 = datetime_utc(2020, 5, 1, 20)
         creation_time_2 = creation_time_1 - timedelta(hours=5)
         creation_time_3 = creation_time_1 + timedelta(days=2)
 

--- a/tests/use_cases/test_show_p_account_details.py
+++ b/tests/use_cases/test_show_p_account_details.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit.use_cases.show_p_account_details import ShowPAccountDetailsUseCase
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -112,7 +113,7 @@ class ShowPAccountDetailsTests(BaseTestCase):
         assert len(response.transfers) == 2
 
     def test_that_newest_transfers_are_shown_first(self) -> None:
-        self.datetime_service.freeze_time(datetime(2025, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2025, 1, 1))
         planner = self.company_generator.create_company()
         self.plan_generator.create_plan(planner=planner)
         self.datetime_service.advance_time(timedelta(days=1))
@@ -136,7 +137,7 @@ class ShowPAccountDetailsTests(BaseTestCase):
         is_public_service: bool,
     ) -> None:
         EXPECTED_VOLUME = Decimal(8.5)
-        EXPECTED_TIMESTAMP = datetime(2025, 1, 1)
+        EXPECTED_TIMESTAMP = datetime_utc(2025, 1, 1)
         EXPECTED_TRANSFER_TYPE = (
             TransferType.credit_public_p if is_public_service else TransferType.credit_p
         )
@@ -250,9 +251,9 @@ class ShowPAccountDetailsTests(BaseTestCase):
         COSTS_PER_CONSUMPTION = TOTAL_COSTS / AMOUNT_PRODUCED
         CONSUMPTION_1 = 10
         CONSUMPTION_2 = 20
-        PLAN_APPROVED_DATE = datetime(2025, 1, 1)
-        CONSUMPTION_DATE_1 = datetime(2025, 1, 2)
-        CONSUMPTION_DATE_2 = datetime(2025, 1, 3)
+        PLAN_APPROVED_DATE = datetime_utc(2025, 1, 1)
+        CONSUMPTION_DATE_1 = datetime_utc(2025, 1, 2)
+        CONSUMPTION_DATE_2 = datetime_utc(2025, 1, 3)
 
         own_company = self.company_generator.create_company()
         other_company = self.company_generator.create_company()
@@ -304,10 +305,10 @@ class ShowPAccountDetailsTests(BaseTestCase):
         CONSUMPTION_1 = 10
         CONSUMPTION_2 = 20
         CONSUMPTION_3 = 30
-        PLAN_APPROVED_DATE = datetime(2025, 1, 1)
-        CONSUMPTION_DATE_1 = datetime(2025, 1, 2)
-        CONSUMPTION_DATE_2 = datetime(2025, 1, 3)
-        CONSUMPTION_DATE_3 = datetime(2025, 1, 4)
+        PLAN_APPROVED_DATE = datetime_utc(2025, 1, 1)
+        CONSUMPTION_DATE_1 = datetime_utc(2025, 1, 2)
+        CONSUMPTION_DATE_2 = datetime_utc(2025, 1, 3)
+        CONSUMPTION_DATE_3 = datetime_utc(2025, 1, 4)
 
         own_company = self.company_generator.create_company()
         other_company = self.company_generator.create_company()
@@ -368,7 +369,7 @@ class ShowPAccountDetailsTests(BaseTestCase):
         self,
         is_public_service: bool,
     ) -> None:
-        PLAN_APPROVED_DATE = datetime(2025, 1, 1)
+        PLAN_APPROVED_DATE = datetime_utc(2025, 1, 1)
         EXPECTED_VOLUME = Decimal(8.5)
         company = self.company_generator.create_company()
         self.datetime_service.freeze_time(PLAN_APPROVED_DATE)

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -6,6 +6,7 @@ from arbeitszeit.records import ProductionCosts
 from arbeitszeit.repositories import DatabaseGateway
 from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit.use_cases import show_prd_account_details
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -269,7 +270,7 @@ class UseCaseTester(BaseTestCase):
     def test_that_correct_plotting_info_is_generated_after_one_plan_approval_and_two_private_consumptions(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         planner = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(
             planner=planner,
@@ -446,7 +447,7 @@ class CompensationForCompanyTests(CompensationTests):
         assert response.transfers[0].volume == EXPECTED_VALUE
 
     def test_that_same_date_as_in_transfer_is_shown(self) -> None:
-        EXPECTED_DATE = datetime(2022, 11, 1)
+        EXPECTED_DATE = datetime_utc(2022, 11, 1)
         planner = self.company_generator.create_company_record()
         self.transfer_generator.create_transfer(
             credit_account=planner.product_account,
@@ -504,7 +505,7 @@ class CompensationForCoopTests(CompensationTests):
         assert response.transfers[0].volume == -TRANSFER_VALUE
 
     def test_that_same_date_as_in_transfer_is_shown(self) -> None:
-        EXPECTED_DATE = datetime(2022, 11, 1)
+        EXPECTED_DATE = datetime_utc(2022, 11, 1)
         planner = self.company_generator.create_company_record()
         self.transfer_generator.create_transfer(
             debit_account=planner.product_account,

--- a/tests/use_cases/test_show_r_account_details.py
+++ b/tests/use_cases/test_show_r_account_details.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.transfers.transfer_type import TransferType
 from arbeitszeit.use_cases import show_r_account_details
+from tests.datetime_service import datetime_utc
 
 from .base_test_case import BaseTestCase
 
@@ -96,7 +97,7 @@ class UseCaseTester(BaseTestCase):
         assert len(response.transfers) == 2
 
     def test_that_newest_transfers_are_shown_first(self) -> None:
-        self.datetime_service.freeze_time(datetime(2025, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2025, 1, 1))
         planner = self.company_generator.create_company()
         self.plan_generator.create_plan(planner=planner)
         self.datetime_service.advance_time(timedelta(days=1))
@@ -120,7 +121,7 @@ class UseCaseTester(BaseTestCase):
         self, is_public_service: bool
     ) -> None:
         EXPECTED_VOLUME = Decimal(8.5)
-        EXPECTED_TIMESTAMP = datetime(2025, 1, 1)
+        EXPECTED_TIMESTAMP = datetime_utc(2025, 1, 1)
         EXPECTED_TRANSFER_TYPE = (
             TransferType.credit_public_r if is_public_service else TransferType.credit_r
         )
@@ -232,9 +233,9 @@ class UseCaseTester(BaseTestCase):
         COSTS_PER_CONSUMPTION = TOTAL_COSTS / AMOUNT_PRODUCED
         CONSUMPTION_1 = 10
         CONSUMPTION_2 = 20
-        PLAN_APPROVED_DATE = datetime(2025, 1, 1)
-        CONSUMPTION_DATE_1 = datetime(2025, 1, 2)
-        CONSUMPTION_DATE_2 = datetime(2025, 1, 3)
+        PLAN_APPROVED_DATE = datetime_utc(2025, 1, 1)
+        CONSUMPTION_DATE_1 = datetime_utc(2025, 1, 2)
+        CONSUMPTION_DATE_2 = datetime_utc(2025, 1, 3)
 
         own_company = self.company_generator.create_company()
         other_company = self.company_generator.create_company()
@@ -282,9 +283,9 @@ class UseCaseTester(BaseTestCase):
     ) -> None:
         own_company = self.company_generator.create_company()
 
-        TIME_OF_FIRST_CONSUMPTION = datetime(2025, 1, 1)
-        TIME_OF_SECOND_CONSUMPTION = datetime(2025, 1, 3)
-        TIME_OF_THIRD_CONSUMPTION = datetime(2025, 1, 5)
+        TIME_OF_FIRST_CONSUMPTION = datetime_utc(2025, 1, 1)
+        TIME_OF_SECOND_CONSUMPTION = datetime_utc(2025, 1, 3)
+        TIME_OF_THIRD_CONSUMPTION = datetime_utc(2025, 1, 5)
 
         VALUE_OF_FIRST_CONSUMPTION = Decimal(10)
         VALUE_OF_SECOND_CONSUMPTION = Decimal(12.5)
@@ -351,7 +352,7 @@ class UseCaseTester(BaseTestCase):
     def test_that_correct_plotting_info_is_generated_after_receiving_of_credit_for_liquid_means_of_production(
         self,
     ) -> None:
-        PLAN_APPROVED_DATE = datetime(2025, 1, 1)
+        PLAN_APPROVED_DATE = datetime_utc(2025, 1, 1)
         EXPECTED_VOLUME = Decimal(8.5)
         company = self.company_generator.create_company()
         self.datetime_service.freeze_time(PLAN_APPROVED_DATE)

--- a/tests/use_cases/test_start_page.py
+++ b/tests/use_cases/test_start_page.py
@@ -1,9 +1,8 @@
-from datetime import datetime
 from unittest import TestCase
 
 from arbeitszeit.use_cases.start_page import StartPageUseCase
 from tests.data_generators import PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.datetime_service import FakeDatetimeService, datetime_utc
 
 from .dependency_injection import get_dependency_injector
 
@@ -32,7 +31,7 @@ class UseCaseTester(TestCase):
         self.assertEqual(len(response.latest_plans), 3)
 
     def test_that_correct_approval_date_of_plan_is_returned(self) -> None:
-        expected_date = datetime(2022, 12, 1, 10)
+        expected_date = datetime_utc(2022, 12, 1, 10)
         self.datetime_service.freeze_time(expected_date)
         self.plan_generator.create_plan()
         response = self.use_case.show_start_page()

--- a/tests/www/controllers/test_change_user_email_address_controller.py
+++ b/tests/www/controllers/test_change_user_email_address_controller.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 from parameterized import parameterized
@@ -6,6 +6,7 @@ from parameterized import parameterized
 from arbeitszeit_web.www.controllers.change_user_email_address_controller import (
     ChangeUserEmailAddressController,
 )
+from tests.datetime_service import datetime_utc
 from tests.forms import ConfirmEmailAddressChangeFormImpl
 from tests.www.base_test_case import BaseTestCase
 
@@ -25,7 +26,7 @@ class ExtractEmailAddressesControllerTests(BaseTestCase):
         self,
         td: timedelta,
     ) -> None:
-        TOKEN_CREATION = datetime(2020, 1, 1)
+        TOKEN_CREATION = datetime_utc(2020, 1, 1)
         self.datetime_service.freeze_time(TOKEN_CREATION)
         token = self.token_service.generate_token(input="old_email:new_email")
         self.datetime_service.freeze_time(TOKEN_CREATION + td)
@@ -42,7 +43,7 @@ class ExtractEmailAddressesControllerTests(BaseTestCase):
         self,
         td: timedelta,
     ) -> None:
-        TOKEN_CREATION = datetime(2020, 1, 1)
+        TOKEN_CREATION = datetime_utc(2020, 1, 1)
         self.datetime_service.freeze_time(TOKEN_CREATION)
         token = self.token_service.generate_token(input="old_email:new_email")
         self.datetime_service.freeze_time(TOKEN_CREATION + td)

--- a/tests/www/controllers/test_confirm_company_controller.py
+++ b/tests/www/controllers/test_confirm_company_controller.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from arbeitszeit_web.www.controllers.confirm_company_controller import (
     ConfirmCompanyController,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -29,14 +30,14 @@ class ConfirmCompanyControllerTests(BaseTestCase):
         assert request.email_address == expected_email_address
 
     def test_token_valid_after_23_hours_and_59_minutes(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token("bla")
         self.datetime_service.advance_time(timedelta(hours=23, minutes=59))
         request = self.controller.process_request(token=token)
         assert request
 
     def test_token_not_valid_after_1_day_and_1_minute(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token("bla")
         self.datetime_service.advance_time(timedelta(days=1, minutes=1))
         request = self.controller.process_request(token=token)

--- a/tests/www/controllers/test_confirm_member_controller.py
+++ b/tests/www/controllers/test_confirm_member_controller.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from arbeitszeit_web.www.controllers.confirm_member_controller import (
     ConfirmMemberController,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -31,7 +32,7 @@ class ConfirmMemberControllerTests(BaseTestCase):
     def test_that_no_request_is_yielded_if_token_is_1_day_and_one_minute_old(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token("test@test.test")
         self.datetime_service.advance_time(timedelta(days=1, minutes=1))
         request = self.controller.process_request(token=token)
@@ -40,7 +41,7 @@ class ConfirmMemberControllerTests(BaseTestCase):
     def test_that_a_proper_request_is_yielded_if_token_is_23_hours_and_59_minutes_old(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         token = self.token_service.generate_token("test@test.test")
         self.datetime_service.advance_time(timedelta(hours=23, minutes=59))
         request = self.controller.process_request(token=token)

--- a/tests/www/presenters/data_generators.py
+++ b/tests/www/presenters/data_generators.py
@@ -37,9 +37,9 @@ class QueriedPlanGenerator:
         if company_id is None:
             company_id = uuid4()
         if approval_date is None:
-            approval_date = datetime.now()
+            approval_date = datetime.min
         if rejection_date is None:
-            rejection_date = datetime.now()
+            rejection_date = datetime.min
         return QueriedPlan(
             plan_id=plan_id,
             company_name="Planner name",

--- a/tests/www/presenters/data_generators.py
+++ b/tests/www/presenters/data_generators.py
@@ -17,6 +17,7 @@ from arbeitszeit.use_cases.query_plans import (
     QueriedPlan,
     QueryPlansRequest,
 )
+from tests.datetime_service import datetime_utc
 
 
 class QueriedPlanGenerator:
@@ -136,7 +137,7 @@ class PlanDetailsGenerator:
         price_per_unit: Decimal = Decimal(0.061),
         is_cooperating: bool = False,
         cooperation: Optional[UUID] = None,
-        creation_date: datetime = datetime(2023, 5, 1),
+        creation_date: datetime = datetime_utc(2023, 5, 1),
         approval_date: Optional[datetime] = None,
         expiration_date: Optional[datetime] = None,
     ) -> PlanDetails:

--- a/tests/www/presenters/test_get_company_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_company_dashboard_presenter.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4
 
@@ -9,6 +8,7 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.get_company_dashboard_presenter import (
     GetCompanyDashboardPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -92,7 +92,7 @@ class CompanyDashboardPresenterTests(CompanyDashboardBaseTestCase):
         self.assertTrue(view_model.has_latest_plans)
 
     def test_presenter_correctly_formats_date_of_latest_plans(self):
-        self.datetime_service.freeze_time(datetime(2022, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2022, 1, 1))
         approval_time = self.datetime_service.now()
         view_model = self.presenter.present(
             self.get_use_case_response(

--- a/tests/www/presenters/test_get_company_summary_presenter.py
+++ b/tests/www/presenters/test_get_company_summary_presenter.py
@@ -1,5 +1,4 @@
 from dataclasses import replace
-from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -16,13 +15,14 @@ from arbeitszeit_web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
 )
 from tests.control_thresholds import ControlThresholdsTestImpl
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 RESPONSE_WITH_2_PLANS = GetCompanySummarySuccess(
     id=uuid4(),
     name="Company Name",
     email="comp_mail@cp.org",
-    registered_on=datetime(2022, 1, 2),
+    registered_on=datetime_utc(2022, 1, 2),
     expectations=Expectations(
         Decimal("1"), Decimal("2"), Decimal("3"), Decimal("-4.561")
     ),

--- a/tests/www/presenters/test_get_coordination_transfer_request_details_presenter.py
+++ b/tests/www/presenters/test_get_coordination_transfer_request_details_presenter.py
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases.get_coordination_transfer_request_details import (
 from arbeitszeit_web.www.presenters.get_coordination_transfer_request_details_presenter import (
     GetCoordinationTransferRequestDetailsPresenter as Presenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -19,7 +20,7 @@ class GetDetailsPresenterTests(BaseTestCase):
         self.session.login_company(company=self.company)
 
     def test_that_request_date_is_formatted_correctly_in_view_model(self):
-        date = datetime(2021, 1, 1)
+        date = datetime_utc(2021, 1, 1)
         response = self.get_use_case_response(request_date=date)
         view_model = self.presenter.present(response)
         assert view_model.request_date == self.datetime_service.format_datetime(
@@ -101,7 +102,7 @@ class GetDetailsPresenterTests(BaseTestCase):
 
     def get_use_case_response(
         self,
-        request_date: datetime = datetime(2021, 1, 1),
+        request_date: datetime = datetime_utc(2021, 1, 1),
         cooperation_id: UUID = uuid4(),
         cooperation_name: str = "Test Cooperation",
         candidate_id: UUID = uuid4(),

--- a/tests/www/presenters/test_get_coordination_transfer_request_details_presenter.py
+++ b/tests/www/presenters/test_get_coordination_transfer_request_details_presenter.py
@@ -19,9 +19,12 @@ class GetDetailsPresenterTests(BaseTestCase):
         self.session.login_company(company=self.company)
 
     def test_that_request_date_is_formatted_correctly_in_view_model(self):
-        response = self.get_use_case_response(request_date=datetime(2021, 1, 1))
+        date = datetime(2021, 1, 1)
+        response = self.get_use_case_response(request_date=date)
         view_model = self.presenter.present(response)
-        self.assertEqual(view_model.request_date, "01.01.2021 00:00")
+        assert view_model.request_date == self.datetime_service.format_datetime(
+            date=date, fmt="%d.%m.%Y %H:%M", zone="Europe/Berlin"
+        )
 
     def test_that_correct_cooperation_summary_url_is_displayed(
         self,

--- a/tests/www/presenters/test_get_draft_details_presenter.py
+++ b/tests/www/presenters/test_get_draft_details_presenter.py
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess
 from arbeitszeit_web.www.presenters.get_draft_details_presenter import (
     GetDraftDetailsPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
 
@@ -154,7 +155,7 @@ class DraftDetailsPresenterTests(BaseTestCase):
         resources_cost: Decimal = Decimal(7),
         labour_cost: Decimal = Decimal(7),
         is_public_service: bool = False,
-        creation_timestamp: datetime = datetime(2000, 1, 1),
+        creation_timestamp: datetime = datetime_utc(2000, 1, 1),
     ) -> DraftDetailsSuccess:
         return DraftDetailsSuccess(
             planner_id=uuid4(),

--- a/tests/www/presenters/test_get_member_account_presenter.py
+++ b/tests/www/presenters/test_get_member_account_presenter.py
@@ -10,6 +10,7 @@ from arbeitszeit.use_cases.get_member_account import (
 from arbeitszeit_web.www.presenters.get_member_account_presenter import (
     GetMemberAccountPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -72,7 +73,7 @@ class TestPresenter(BaseTestCase):
     def test_that_date_of_transfer_is_formatted_correctly_as_berlin_summertime(
         self,
     ):
-        test_date = datetime(2022, 8, 1, 10, 30)
+        test_date = datetime_utc(2022, 8, 1, 10, 30)
         response = self.get_use_case_response([self.get_transfer(date=test_date)])
         view_model = self.presenter.present_member_account(response)
         self.assertEqual(view_model.transfers[0].date, "01.08.2022 12:30")

--- a/tests/www/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_member_dashboard_presenter.py
@@ -1,9 +1,7 @@
-from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID, uuid4
 
-from dateutil import tz
 from parameterized import parameterized
 
 from arbeitszeit.use_cases import get_member_dashboard
@@ -122,7 +120,7 @@ class GetMemberDashboardPresenterTests(BaseTestCase):
         self.assertEqual(presentation.three_latest_plans[0].prd_name, expected_name)
 
     def test_approval_date_of_latest_plans_is_correctly_formatted(self):
-        now = datetime.now(tz=tz.gettz("Europe/Berlin"))
+        now = self.datetime_service.now()
         response = self.get_response(
             three_latest_plans=[
                 get_member_dashboard.PlanDetails(

--- a/tests/www/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_member_dashboard_presenter.py
@@ -114,7 +114,7 @@ class GetMemberDashboardPresenterTests(BaseTestCase):
                 get_member_dashboard.PlanDetails(
                     plan_id=uuid4(),
                     prd_name=expected_name,
-                    approval_date=datetime.now(),
+                    approval_date=self.datetime_service.now(),
                 )
             ]
         )
@@ -144,7 +144,7 @@ class GetMemberDashboardPresenterTests(BaseTestCase):
                 get_member_dashboard.PlanDetails(
                     plan_id=plan_id,
                     prd_name="test name",
-                    approval_date=datetime.now(),
+                    approval_date=self.datetime_service.now(),
                 )
             ]
         )

--- a/tests/www/presenters/test_list_coordinations_of_cooperation_presenter.py
+++ b/tests/www/presenters/test_list_coordinations_of_cooperation_presenter.py
@@ -8,6 +8,7 @@ from arbeitszeit.use_cases.list_coordinations_of_cooperation import (
 from arbeitszeit_web.www.presenters.list_coordinations_of_cooperation_presenter import (
     ListCoordinationsOfCooperationPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -76,7 +77,7 @@ class ListCoordinationsPresenterTests(BaseTestCase):
         self.assertEqual(view_model.coordinations[0].coordinator_url, expected_url)
 
     def test_presenter_shows_correct_start_time(self) -> None:
-        expected_start_time = datetime(2020, 1, 1, 12, 0)
+        expected_start_time = datetime_utc(2020, 1, 1, 12, 0)
         expected_formatted_start_time = self.datetime_service.format_datetime(
             date=expected_start_time,
             zone="Europe/Berlin",
@@ -96,7 +97,7 @@ class ListCoordinationsPresenterTests(BaseTestCase):
                 CoordinationInfo(
                     coordinator_id=uuid4(),
                     coordinator_name="fake name",
-                    start_time=datetime(2020, 1, 1, 12, 0),
+                    start_time=datetime_utc(2020, 1, 1, 12, 0),
                     end_time=None,
                 )
             ],
@@ -107,7 +108,7 @@ class ListCoordinationsPresenterTests(BaseTestCase):
         self.assertEqual(view_model.coordinations[0].end_time, "-")
 
     def test_presenter_shows_correct_end_time_if_coordination_has_some(self) -> None:
-        expected_end_time = datetime(2022, 3, 10, 13, 0)
+        expected_end_time = datetime_utc(2022, 3, 10, 13, 0)
         expected_formatted_end_time = self.datetime_service.format_datetime(
             date=expected_end_time,
             zone="Europe/Berlin",
@@ -160,8 +161,8 @@ class ListCoordinationsPresenterTests(BaseTestCase):
         self,
         coordinator_id: UUID = uuid4(),
         coordinator_name: str = "fake coordinator name",
-        start_time: datetime = datetime(2020, 1, 1, 12, 0),
-        end_time: datetime = datetime(2022, 3, 10, 13, 0),
+        start_time: datetime = datetime_utc(2020, 1, 1, 12, 0),
+        end_time: datetime = datetime_utc(2022, 3, 10, 13, 0),
         cooperation_id: UUID = uuid4(),
         cooperation_name: str = "Some coop test name",
     ) -> ListCoordinationsOfCooperationUseCase.Response:

--- a/tests/www/presenters/test_list_registered_hours_worked_presenter.py
+++ b/tests/www/presenters/test_list_registered_hours_worked_presenter.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from arbeitszeit.use_cases import list_registered_hours_worked
 from arbeitszeit_web.www.presenters import list_registered_hours_worked_presenter
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -85,7 +86,7 @@ class ListRegisteredHoursWorkedPresenterTests(BaseTestCase):
         assert view_model.registered_hours_worked[0].worker_name == worker_name
 
     def test_registered_on_from_response_is_formatted_correctly(self) -> None:
-        registered_on = datetime(2021, 1, 1, 12, 0)
+        registered_on = datetime_utc(2021, 1, 1, 12, 0)
         expected_registered_on = self.datetime_service.format_datetime(
             date=registered_on, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
         )
@@ -106,7 +107,7 @@ class ListRegisteredHoursWorkedPresenterTests(BaseTestCase):
         hours: Decimal = Decimal("8.0"),
         worker_id: UUID = uuid4(),
         worker_name: str = "worker_name",
-        registered_on: datetime = datetime(2021, 1, 1),
+        registered_on: datetime = datetime_utc(2021, 1, 1),
     ) -> list_registered_hours_worked.RegisteredHoursWorked:
         return list_registered_hours_worked.RegisteredHoursWorked(
             hours=hours,

--- a/tests/www/presenters/test_list_transfers_presenter.py
+++ b/tests/www/presenters/test_list_transfers_presenter.py
@@ -10,6 +10,7 @@ from arbeitszeit_web.pagination import DEFAULT_PAGE_SIZE
 from arbeitszeit_web.www.presenters.list_transfers_presenter import (
     ListTransfersPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -20,7 +21,7 @@ class ListTransfersPresenterBase(BaseTestCase):
 
     def create_transfer_entry(
         self,
-        date: datetime = datetime(2024, 1, 1, 12, 0),
+        date: datetime = datetime_utc(2024, 1, 1, 12, 0),
         debtor: UUID | None = UUID("00000000-0000-0000-0000-000000000000"),
         debit_account: UUID | None = UUID("00000000-0000-0000-0000-000000000000"),
         debtor_name: str | None = "Debtor",
@@ -137,7 +138,7 @@ class ResultsTests(ListTransfersPresenterBase):
         assert len(view_model.results.rows) == num_results
 
     def test_that_transfer_date_is_converted_to_correct_format(self) -> None:
-        date = datetime(2023, 1, 1, 10, 30)
+        date = datetime_utc(2023, 1, 1, 10, 30)
         uc_response = self.create_use_case_response(
             transfers=[self.create_transfer_entry(date=date)]
         )

--- a/tests/www/presenters/test_private_consumptions_presenter.py
+++ b/tests/www/presenters/test_private_consumptions_presenter.py
@@ -6,6 +6,7 @@ from arbeitszeit.use_cases import query_private_consumptions as use_case
 from arbeitszeit_web.www.presenters.private_consumptions_presenter import (
     PrivateConsumptionsPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -16,19 +17,19 @@ class PresenterTests(BaseTestCase):
 
     def test_that_date_is_formatted_properly(self) -> None:
         response = self.create_response_with_one_consumption(
-            consumption_timestamp=datetime(2000, 1, 1)
+            consumption_timestamp=datetime_utc(2000, 1, 1)
         )
         view_model = self.presenter.present_private_consumptions(response)
         self.assertEqual(
             view_model.consumptions[0].consumption_date,
             self.datetime_service.format_datetime(
-                datetime(2000, 1, 1),
+                datetime_utc(2000, 1, 1),
                 fmt="%d.%m.%Y",
             ),
         )
 
     def create_response_with_one_consumption(
-        self, consumption_timestamp: datetime = datetime(2020, 1, 1)
+        self, consumption_timestamp: datetime = datetime_utc(2020, 1, 1)
     ) -> use_case.Response:
         return use_case.Response(
             consumptions=[

--- a/tests/www/presenters/test_review_registered_consumptions_presenter.py
+++ b/tests/www/presenters/test_review_registered_consumptions_presenter.py
@@ -13,6 +13,7 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.review_registered_consumptions_presenter import (
     ReviewRegisteredConsumptionsPresenter,
 )
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -59,7 +60,7 @@ class ReviewRegisteredConsumptionsPresenterTests(BaseTestCase):
     def test_that_an_use_case_response_results_in_a_view_model_with_a_formatted_consumption_date(
         self,
     ) -> None:
-        date = datetime(2021, 1, 1, 22, 1)
+        date = datetime_utc(2021, 1, 1, 22, 1)
         consumption = self._create_consumption(date=date)
         use_case_response = UseCase.Response(consumptions=[consumption])
         view_model = self.presenter.present(use_case_response)
@@ -152,7 +153,7 @@ class ReviewRegisteredConsumptionsPresenterTests(BaseTestCase):
 
     def _create_consumption(
         self,
-        date: datetime = datetime(2021, 1, 1),
+        date: datetime = datetime_utc(2021, 1, 1),
         is_private_consumption: Optional[bool] = None,
         consumer_name: str = "consumer_name",
         consumer_id: UUID = uuid4(),

--- a/tests/www/presenters/test_review_registered_consumptions_presenter.py
+++ b/tests/www/presenters/test_review_registered_consumptions_presenter.py
@@ -59,10 +59,13 @@ class ReviewRegisteredConsumptionsPresenterTests(BaseTestCase):
     def test_that_an_use_case_response_results_in_a_view_model_with_a_formatted_consumption_date(
         self,
     ) -> None:
-        consumption = self._create_consumption(date=datetime(2021, 1, 1, 22, 1))
+        date = datetime(2021, 1, 1, 22, 1)
+        consumption = self._create_consumption(date=date)
         use_case_response = UseCase.Response(consumptions=[consumption])
         view_model = self.presenter.present(use_case_response)
-        assert view_model.consumptions[0].date == "01.01.2021 22:01"
+        assert view_model.consumptions[0].date == self.datetime_service.format_datetime(
+            date=date, fmt="%d.%m.%Y %H:%M", zone="Europe/Berlin"
+        )
 
     def test_that_an_use_case_response_results_in_a_view_model_with_the_consumer_name(
         self,

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -18,13 +17,14 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_cooperations_presenter import (
     ShowMyCooperationsPresenter,
 )
+from tests.datetime_service import datetime_min_utc
 from tests.www.base_test_case import BaseTestCase
 
 LIST_COORDINATIONS_RESPONSE_LEN_1 = ListCoordinationsOfCompanyResponse(
     coordinations=[
         CooperationInfo(
             id=uuid4(),
-            creation_date=datetime.min,
+            creation_date=datetime_min_utc(),
             name="coop name",
             definition="first paragraph\nsecond paragraph",
             count_plans_in_coop=3,

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -24,7 +24,7 @@ LIST_COORDINATIONS_RESPONSE_LEN_1 = ListCoordinationsOfCompanyResponse(
     coordinations=[
         CooperationInfo(
             id=uuid4(),
-            creation_date=datetime.now(),
+            creation_date=datetime.min,
             name="coop name",
             definition="first paragraph\nsecond paragraph",
             count_plans_in_coop=3,

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
@@ -12,6 +12,7 @@ from arbeitszeit.use_cases.show_my_plans import (
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPresenter
 from tests.data_generators import CooperationGenerator, PlanGenerator
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -23,7 +24,7 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.coop_generator = self.injector.get(CooperationGenerator)
         self.session.login_company(uuid4())
         self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
 
     def test_show_correct_notification_when_user_has_no_plans(self) -> None:
         self.presenter.present(
@@ -84,7 +85,7 @@ class ShowMyPlansPresenterTests(BaseTestCase):
     def test_presenter_shows_correct_info_of_one_single_plan_that_is_cooperating(
         self,
     ) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         coop = self.coop_generator.create_cooperation()
         plan = self.plan_generator.create_plan_record(cooperation=coop)
         RESPONSE_WITH_COOPERATING_PLAN = self.response_with_one_active_plan(
@@ -154,7 +155,7 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         )
 
     def test_that_relative_expiration_is_calculated_correctly(self) -> None:
-        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
         plan = self._create_active_plan(timeframe=5)
         view_model = self.presenter.present(self.response_with_one_active_plan(plan))
         self.assertEqual(
@@ -179,7 +180,7 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.assertEqual(view_model.drafts.rows[0].product_name, expected_name)
 
     def test_that_draft_creation_date_is_filled_in_correctly(self) -> None:
-        expected_creation_time = datetime(2020, 5, 1)
+        expected_creation_time = datetime_utc(2020, 5, 1)
         self.datetime_service.freeze_time(expected_creation_time)
         response = self.response_with_one_draft()
         view_model = self.presenter.present(response)

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -9,6 +9,7 @@ from arbeitszeit.use_cases.show_p_account_details import (
 from arbeitszeit_web.www.presenters.show_p_account_details_presenter import (
     ShowPAccountDetailsPresenter,
 )
+from tests.datetime_service import datetime_min_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -86,7 +87,7 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
     def get_transfer_info(
         self,
         type: TransferType = TransferType.credit_p,
-        date: datetime = datetime.min,
+        date: datetime = datetime_min_utc(),
         volume: Decimal = Decimal(10.002),
     ) -> UseCase.TransferInfo:
         return UseCase.TransferInfo(type=type, date=date, volume=volume)

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -86,7 +86,7 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
     def get_transfer_info(
         self,
         type: TransferType = TransferType.credit_p,
-        date: datetime = datetime.now(),
+        date: datetime = datetime.min,
         volume: Decimal = Decimal(10.002),
     ) -> UseCase.TransferInfo:
         return UseCase.TransferInfo(type=type, date=date, volume=volume)

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from typing import List
 from uuid import UUID, uuid4
@@ -10,6 +9,7 @@ from arbeitszeit.use_cases import show_prd_account_details
 from arbeitszeit_web.www.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
 )
+from tests.datetime_service import datetime_min_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -260,7 +260,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
     ) -> None:
         transfer = show_prd_account_details.TransferInfo(
             type=TransferType.credit_p,
-            date=datetime.min,
+            date=datetime_min_utc(),
             volume=Decimal(10.007),
             peer=None,
         )
@@ -273,7 +273,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
     ) -> None:
         transfer = show_prd_account_details.TransferInfo(
             type=TransferType.credit_p,
-            date=datetime.min,
+            date=datetime_min_utc(),
             volume=Decimal(10.007),
             peer=None,
         )
@@ -334,7 +334,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             peer = show_prd_account_details.MemberPeer()
         return show_prd_account_details.TransferInfo(
             type=transfer_type,
-            date=datetime.min,
+            date=datetime_min_utc(),
             volume=volume,
             peer=peer,
         )

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -260,7 +260,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
     ) -> None:
         transfer = show_prd_account_details.TransferInfo(
             type=TransferType.credit_p,
-            date=datetime.now(),
+            date=datetime.min,
             volume=Decimal(10.007),
             peer=None,
         )
@@ -273,7 +273,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
     ) -> None:
         transfer = show_prd_account_details.TransferInfo(
             type=TransferType.credit_p,
-            date=datetime.now(),
+            date=datetime.min,
             volume=Decimal(10.007),
             peer=None,
         )
@@ -334,7 +334,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             peer = show_prd_account_details.MemberPeer()
         return show_prd_account_details.TransferInfo(
             type=transfer_type,
-            date=datetime.now(),
+            date=datetime.min,
             volume=volume,
             peer=peer,
         )

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from typing import List
 from uuid import UUID, uuid4
@@ -8,18 +7,19 @@ from arbeitszeit.use_cases import show_r_account_details
 from arbeitszeit_web.www.presenters.show_r_account_details_presenter import (
     ShowRAccountDetailsPresenter,
 )
+from tests.datetime_service import datetime_min_utc
 from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = show_r_account_details.TransferInfo(
     type=TransferType.credit_r,
-    date=datetime.min,
+    date=datetime_min_utc(),
     volume=Decimal(10.007),
 )
 
 DEFAULT_INFO2 = show_r_account_details.TransferInfo(
     type=TransferType.credit_r,
-    date=datetime.min,
+    date=datetime_min_utc(),
     volume=Decimal(20.103),
 )
 

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -13,13 +13,13 @@ from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = show_r_account_details.TransferInfo(
     type=TransferType.credit_r,
-    date=datetime.now(),
+    date=datetime.min,
     volume=Decimal(10.007),
 )
 
 DEFAULT_INFO2 = show_r_account_details.TransferInfo(
     type=TransferType.credit_r,
-    date=datetime.now(),
+    date=datetime.min,
     volume=Decimal(20.103),
 )
 

--- a/tests/www/presenters/test_start_page_presenter.py
+++ b/tests/www/presenters/test_start_page_presenter.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.start_page import StartPageUseCase
 from arbeitszeit_web.www.presenters.start_page_presenter import StartPagePresenter
+from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -25,7 +26,7 @@ class PresenterTester(BaseTestCase):
     def test_that_view_model_shows_plans_approval_date_correctly_formatted(
         self,
     ) -> None:
-        plan = self.get_latest_plan(approval_date=datetime(2022, 10, 1))
+        plan = self.get_latest_plan(approval_date=datetime_utc(2022, 10, 1))
         response = self.get_response([plan])
         view_model = self.presenter.show_start_page(response)
         self.assertEqual(view_model.plans[0].approval_date, "01.10.")
@@ -40,7 +41,7 @@ class PresenterTester(BaseTestCase):
         product_name: Optional[str] = None,
     ) -> StartPageUseCase.PlanDetail:
         if approval_date is None:
-            approval_date = datetime(2022, 5, 1)
+            approval_date = datetime_utc(2022, 5, 1)
         if plan_id is None:
             plan_id = uuid4()
         if product_name is None:


### PR DESCRIPTION
This PR consists of several commits around date, time and timezones, all done in preparation of issue #459. The biggest change is that in general we now use timezone-aware datetime objects (set to UTC) in our code. We only convert them to different timezones in the presenter. We convert them to timezone-naive UTC in the database.
