### PR TITLE
Reduce test dependency on business records

### DIFF
--- a/arbeitszeit/interactors/get_coop_summary.py
+++ b/arbeitszeit/interactors/get_coop_summary.py
@@ -81,7 +81,7 @@ class GetCoopSummaryInteractor:
     def _get_cooperative_price(self, plans: list[Plan]) -> Optional[Decimal]:
         if not plans:
             return None
-        return self.price_calculator.calculate_cooperative_price(plans[0])
+        return self.price_calculator.calculate_cooperative_price(plans[0].id)
 
     def _get_associated_plans(
         self, plans: list[Plan], requester: UUID

--- a/arbeitszeit/interactors/query_plans.py
+++ b/arbeitszeit/interactors/query_plans.py
@@ -106,7 +106,9 @@ class QueryPlansInteractor:
         planner: records.Company,
         cooperation: Optional[records.Cooperation],
     ) -> QueriedPlan:
-        price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
+        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
+        if price_per_unit is None:
+            price_per_unit = plan.price_per_unit()
         assert plan.approval_date
         return QueriedPlan(
             plan_id=plan.id,

--- a/arbeitszeit/interactors/register_private_consumption.py
+++ b/arbeitszeit/interactors/register_private_consumption.py
@@ -59,17 +59,19 @@ class RegisterPrivateConsumption:
     ) -> RegisterPrivateConsumptionResponse:
         plan, planner = self._get_plan_and_planner(request)
         consumer = self._get_consumer(request)
-        coop_price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
+        coop_price = self.price_calculator.calculate_cooperative_price(plan.id)
+        if coop_price is None:
+            coop_price = plan.price_per_unit()
         consumption_transfer = self._create_private_consumption_transfer(
             debit_account=consumer.account,
             credit_account=planner.product_account,
-            value=coop_price_per_unit * request.amount,
+            value=coop_price * request.amount,
         )
         compensation_transfer = self._get_compensation_transfer_if_any(
             plan_id=plan.id,
             planner_product_account=planner.product_account,
             plan_price_per_unit=plan.price_per_unit(),
-            coop_price_per_unit=coop_price_per_unit,
+            coop_price_per_unit=coop_price,
             consumed_amount=request.amount,
         )
         self.database_gateway.create_private_consumption(

--- a/arbeitszeit/interactors/register_productive_consumption.py
+++ b/arbeitszeit/interactors/register_productive_consumption.py
@@ -112,20 +112,22 @@ class RegisterProductiveConsumptionInteractor:
         consumer: Company,
         plan: Plan,
     ) -> None:
-        coop_price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
+        coop_price = self.price_calculator.calculate_cooperative_price(plan.id)
+        if coop_price is None:
+            coop_price = plan.price_per_unit()
         planner = self.database_gateway.get_companies().with_id(plan.planner).first()
         assert planner
         consumption_transfer = self._create_productive_consumption_transfer(
             consumption_type=consumption_type,
             consumer=consumer,
             planner_product_account=planner.product_account,
-            value=coop_price_per_unit * consumed_amount,
+            value=coop_price * consumed_amount,
         )
         compensation_transfer = self._get_compensation_transfer_if_any(
             plan_id=plan.id,
             planner_product_account=planner.product_account,
             plan_price_per_unit=plan.price_per_unit(),
-            coop_price_per_unit=coop_price_per_unit,
+            coop_price_per_unit=coop_price,
             consumed_amount=consumed_amount,
         )
         self.database_gateway.create_productive_consumption(

--- a/arbeitszeit/interactors/show_my_plans.py
+++ b/arbeitszeit/interactors/show_my_plans.py
@@ -103,10 +103,13 @@ class ShowMyPlansInteractor:
     def _create_plan_info_from_plan(
         self, plan: records.Plan, cooperation: Optional[records.Cooperation]
     ) -> PlanInfo:
+        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
+        if price_per_unit is None:
+            price_per_unit = plan.price_per_unit()
         return PlanInfo(
             id=plan.id,
             prd_name=plan.prd_name,
-            price_per_unit=self.price_calculator.calculate_cooperative_price(plan),
+            price_per_unit=price_per_unit,
             is_public_service=plan.is_public_service,
             plan_creation_date=plan.plan_creation_date,
             approval_date=plan.approval_date,

--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -229,13 +229,6 @@ class Plan:
     def is_expired_as_of(self, timestamp: datetime) -> bool:
         return self.expiration_date is not None and timestamp >= self.expiration_date
 
-    def to_summary(self) -> PlanSummary:
-        return PlanSummary(
-            production_costs=self.production_costs.total_cost(),
-            duration_in_days=self.timeframe,
-            amount=self.prd_amount,
-        )
-
     def cost_per_unit(self) -> Decimal:
         if self.prd_amount == 0:
             return Decimal(0)
@@ -323,13 +316,6 @@ class AccountCredentials:
     id: UUID
     email_address: str
     password_hash: str
-
-
-@dataclass
-class PlanSummary:
-    production_costs: Decimal
-    duration_in_days: int
-    amount: int
 
 
 @dataclass

--- a/arbeitszeit/services/plan_details.py
+++ b/arbeitszeit/services/plan_details.py
@@ -51,9 +51,8 @@ class PlanDetailsService:
         if not plan_and_cooperation:
             return None
         plan, cooperation = plan_and_cooperation
-        if plan.is_active_as_of(now):
-            price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
-        else:
+        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
+        if price_per_unit is None:
             price_per_unit = plan.price_per_unit()
         planner = self.database_gateway.get_companies().with_id(plan.planner).first()
         assert planner

--- a/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
@@ -137,7 +137,7 @@ class ShowMyPlansPresenter:
             rows=[
                 ActivePlansRow(
                     plan_details_url=self.user_url_index.get_plan_details_url(plan.id),
-                    prd_name=f"{plan.prd_name}",
+                    prd_name=plan.prd_name,
                     price_per_unit=self.__format_price(plan.price_per_unit),
                     approval_date=self.__format_date(plan.approval_date),
                     expiration_date=self.__format_date(plan.expiration_date),

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -336,41 +336,6 @@ class PlanGenerator:
         assert response.draft_id
         return response.draft_id
 
-    def create_plan_record(
-        self,
-        *,
-        amount: int = 100,
-        approved: bool = True,
-        costs: Optional[records.ProductionCosts] = None,
-        description="Beschreibung für Produkt A.",
-        is_public_service: bool = False,
-        planner: Optional[UUID] = None,
-        product_name: str = "Produkt A",
-        production_unit: str = "500 Gramm",
-        timeframe: Optional[int] = None,
-        requested_cooperation: Optional[UUID] = None,
-        cooperation: Optional[UUID] = None,
-        hidden_by_user: bool = False,
-    ) -> records.Plan:
-        # Don't use this method. It is only here for legacy reasons.
-        plan_id = self.create_plan(
-            amount=amount,
-            approved=approved,
-            costs=costs,
-            description=description,
-            is_public_service=is_public_service,
-            planner=planner,
-            product_name=product_name,
-            production_unit=production_unit,
-            timeframe=timeframe,
-            requested_cooperation=requested_cooperation,
-            cooperation=cooperation,
-            hidden_by_user=hidden_by_user,
-        )
-        plan = self.database_gateway.get_plans().with_id(plan_id).first()
-        assert plan
-        return plan
-
 
 @dataclass
 class ConsumptionGenerator:

--- a/tests/interactors/repositories.py
+++ b/tests/interactors/repositories.py
@@ -212,16 +212,14 @@ class PlanResult(QueryResultImpl[Plan]):
 
     def that_are_in_same_cooperation_as(self, plan: UUID) -> Self:
         def items_generator() -> Iterator[records.Plan]:
-            cooperation_id = self.database.relationships.cooperation_to_plan.get_one(
-                plan
-            )
             plan_record = self.database.plans.get(plan)
             if not plan_record:
                 return
+            cooperation_id = self.database.relationships.cooperation_to_plan.get_one(
+                plan
+            )
             if cooperation_id is None:
-                yield from (
-                    other_plan for other_plan in self.items() if other_plan.id == plan
-                )
+                return
             else:
                 for candidate in self.items():
                     candidate_cooperation = (

--- a/tests/records/test_plan.py
+++ b/tests/records/test_plan.py
@@ -1,51 +1,62 @@
 from decimal import Decimal
-from unittest import TestCase
 
+from arbeitszeit import records
 from arbeitszeit.records import ProductionCosts
-from tests.data_generators import PlanGenerator
-from tests.datetime_service import FakeDatetimeService, datetime_utc
-from tests.interactors.dependency_injection import get_dependency_injector
+from tests.datetime_service import datetime_utc
+from tests.interactors.base_test_case import BaseTestCase
 
 
-class TestPlanSalesValue(TestCase):
-    def setUp(self) -> None:
-        self.injector = get_dependency_injector()
-        self.plan_generator = self.injector.get(PlanGenerator)
+class PlanTestBase(BaseTestCase):
+    def create_plan_record(
+        self,
+        is_public_service: bool = False,
+        costs: ProductionCosts = ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+        amount: int = 5,
+        approved: bool = False,
+        timeframe: int = 365,
+    ) -> records.Plan:
+        plan_id = self.plan_generator.create_plan(
+            amount=amount,
+            is_public_service=is_public_service,
+            costs=costs,
+            approved=approved,
+            timeframe=timeframe,
+        )
+        plan = self.database_gateway.get_plans().with_id(plan_id).first()
+        assert plan
+        return plan
 
+
+class TestPlanSalesValue(PlanTestBase):
     def test_expected_sales_value_is_zero_for_public_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record(is_public_service=True)
+        plan = self.create_plan_record(is_public_service=True)
         self.assertEqual(plan.expected_sales_value, Decimal(0))
 
     def test_expected_sales_value_equals_individual_production_costs_for_productive_plan(
         self,
     ) -> None:
-        plan = self.plan_generator.create_plan_record(
+        plan = self.create_plan_record(
             costs=ProductionCosts(Decimal(10), Decimal(5), Decimal(5)), amount=10
         )
         self.assertEqual(plan.expected_sales_value, Decimal(20))
 
 
-class TestPlanExpirationDate(TestCase):
-    def setUp(self) -> None:
-        self.injector = get_dependency_injector()
-        self.plan_generator = self.injector.get(PlanGenerator)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
-
+class TestPlanExpirationDate(PlanTestBase):
     def test_that_plan_has_no_expiration_date_if_plan_has_not_been_approved(
         self,
     ) -> None:
-        plan = self.plan_generator.create_plan_record(approved=False)
+        plan = self.create_plan_record(approved=False)
         self.assertIsNone(plan.expiration_date)
 
     def test_that_plan_has_an_expiration_date_if_plan_has_been_approved(self) -> None:
-        plan = self.plan_generator.create_plan_record(timeframe=2, approved=True)
+        plan = self.create_plan_record(timeframe=2, approved=True)
         self.assertIsNotNone(plan.expiration_date)
 
     def test_that_expiration_date_is_correctly_calculated_if_plan_expires_now(
         self,
     ) -> None:
         self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
-        plan = self.plan_generator.create_plan_record(
+        plan = self.create_plan_record(
             timeframe=1,
             approved=True,
         )
@@ -56,7 +67,7 @@ class TestPlanExpirationDate(TestCase):
         self,
     ) -> None:
         self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
-        plan = self.plan_generator.create_plan_record(
+        plan = self.create_plan_record(
             timeframe=2,
             approved=True,
         )

--- a/tests/services/test_price_calculator.py
+++ b/tests/services/test_price_calculator.py
@@ -12,52 +12,33 @@ class PriceCalculatorTests(BaseTestCase):
         super().setUp()
         self.calculator = self.injector.get(PriceCalculator)
 
-    def test_that_price_of_one_public_plan_is_zero(self) -> None:
-        public_plan = self.plan_generator.create_plan_record(is_public_service=True)
-        price = self.calculator.calculate_cooperative_price(public_plan)
-        assert price == Decimal(0)
-
-    def test_that_price_of_one_plan_that_produces_zero_units_is_zero(self) -> None:
-        plan = self.plan_generator.create_plan_record(
-            costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
-            amount=0,
-        )
+    def test_that_service_returns_none_for_noncooperating_public_plan(self) -> None:
+        plan = self.plan_generator.create_plan(is_public_service=True)
         price = self.calculator.calculate_cooperative_price(plan)
-        assert price == Decimal(0)
+        assert price is None
+
+    def test_that_service_returns_none_for_noncooperating_productive_plan(self) -> None:
+        plan = self.plan_generator.create_plan(is_public_service=False)
+        price = self.calculator.calculate_cooperative_price(plan)
+        assert price is None
 
     def test_that_price_is_zero_when_all_plans_in_cooperation_produce_zero_units(
         self,
     ) -> None:
-        plan_1 = self.plan_generator.create_plan_record(
+        plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
             amount=0,
         )
-        plan_2 = self.plan_generator.create_plan_record(
+        plan_2 = self.plan_generator.create_plan(
             costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
             amount=0,
         )
         self.cooperation_generator.create_cooperation(
-            plans=[plan_1.id, plan_2.id],
+            plans=[plan_1, plan_2],
         )
         price = self.calculator.calculate_cooperative_price(plan_1)
+        assert price is not None
         assert price == Decimal(0)
-
-    @parameterized.expand(
-        [
-            (Decimal(10),),
-            (Decimal(20),),
-        ]
-    )
-    def test_that_price_of_plan_without_cooperation_is_its_own_costs(
-        self,
-        costs: Decimal,
-    ) -> None:
-        plan = self.plan_generator.create_plan_record(
-            costs=ProductionCosts(costs, Decimal(0), Decimal(0)),
-            amount=1,
-        )
-        price = self.calculator.calculate_cooperative_price(plan)
-        self.assertAlmostEqual(price, costs)
 
     @parameterized.expand(
         [
@@ -69,12 +50,13 @@ class PriceCalculatorTests(BaseTestCase):
         self,
         costs: Decimal,
     ) -> None:
-        plan = self.plan_generator.create_plan_record(
+        plan = self.plan_generator.create_plan(
             costs=ProductionCosts(costs, Decimal(0), Decimal(0)),
             amount=1,
         )
-        self.cooperation_generator.create_cooperation(plans=[plan.id])
+        self.cooperation_generator.create_cooperation(plans=[plan])
         price = self.calculator.calculate_cooperative_price(plan)
+        assert price is not None
         self.assertAlmostEqual(price, costs)
 
     @parameterized.expand(
@@ -89,18 +71,19 @@ class PriceCalculatorTests(BaseTestCase):
         costs_2: Decimal,
         expected_price: Decimal,
     ) -> None:
-        plan_1 = self.plan_generator.create_plan_record(
+        plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
         )
-        plan_2 = self.plan_generator.create_plan_record(
+        plan_2 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
             amount=1,
         )
         self.cooperation_generator.create_cooperation(
-            plans=[plan_1.id, plan_2.id],
+            plans=[plan_1, plan_2],
         )
         price = self.calculator.calculate_cooperative_price(plan_1)
+        assert price is not None
         self.assertAlmostEqual(price, expected_price)
 
     @parameterized.expand(
@@ -116,22 +99,23 @@ class PriceCalculatorTests(BaseTestCase):
         costs_3: Decimal,
         expected_price: Decimal,
     ) -> None:
-        plan_1 = self.plan_generator.create_plan_record(
+        plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
         )
-        plan_2 = self.plan_generator.create_plan_record(
+        plan_2 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
             amount=1,
         )
-        plan_3 = self.plan_generator.create_plan_record(
+        plan_3 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_3, Decimal(0), Decimal(0)),
             amount=1,
         )
         self.cooperation_generator.create_cooperation(
-            plans=[plan_1.id, plan_2.id, plan_3.id],
+            plans=[plan_1, plan_2, plan_3],
         )
         price = self.calculator.calculate_cooperative_price(plan_1)
+        assert price is not None
         self.assertAlmostEqual(price, expected_price)
 
     @parameterized.expand(
@@ -149,18 +133,19 @@ class PriceCalculatorTests(BaseTestCase):
         duration_2: int,
         expected_price: Decimal,
     ) -> None:
-        plan_1 = self.plan_generator.create_plan_record(
+        plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
             timeframe=duration_1,
         )
-        plan_2 = self.plan_generator.create_plan_record(
+        plan_2 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_2, Decimal(0), Decimal(0)),
             amount=1,
             timeframe=duration_2,
         )
         self.cooperation_generator.create_cooperation(
-            plans=[plan_1.id, plan_2.id],
+            plans=[plan_1, plan_2],
         )
         price = self.calculator.calculate_cooperative_price(plan_1)
+        assert price is not None
         self.assertAlmostEqual(price, expected_price)

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -1,364 +1,390 @@
-from datetime import timedelta
+from datetime import datetime
 from decimal import Decimal
 from uuid import UUID, uuid4
 
+from parameterized import parameterized
+
 from arbeitszeit.interactors.show_my_plans import (
     PlanInfo,
-    ShowMyPlansInteractor,
-    ShowMyPlansRequest,
     ShowMyPlansResponse,
 )
-from arbeitszeit.records import Plan, PlanDraft
-from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPresenter
-from tests.data_generators import CooperationGenerator, PlanGenerator
 from tests.datetime_service import datetime_utc
 from tests.www.base_test_case import BaseTestCase
 
 
-class ShowMyPlansPresenterTests(BaseTestCase):
+class PresenterBase(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ShowMyPlansPresenter)
-        self.plan_generator = self.injector.get(PlanGenerator)
-        self.coop_generator = self.injector.get(CooperationGenerator)
-        self.session.login_company(uuid4())
-        self.show_my_plans = self.injector.get(ShowMyPlansInteractor)
-        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
 
+    def create_plan_info(
+        self,
+        plan_id: UUID | None = None,
+        prd_name: str = "Product name",
+        price_per_unit: Decimal = Decimal(10),
+        is_public_service: bool = False,
+        plan_creation_date: datetime = datetime_utc(2020, 1, 1),
+        approval_date: datetime | None = None,
+        expiration_date: datetime | None = None,
+        rejection_date: datetime | None = None,
+        is_cooperating: bool = False,
+        cooperation: UUID | None = None,
+    ) -> PlanInfo:
+        if plan_id is None:
+            plan_id = uuid4()
+        return PlanInfo(
+            id=plan_id,
+            prd_name=prd_name,
+            price_per_unit=price_per_unit,
+            is_public_service=is_public_service,
+            plan_creation_date=plan_creation_date,
+            approval_date=approval_date,
+            expiration_date=expiration_date,
+            rejection_date=rejection_date,
+            is_cooperating=is_cooperating,
+            cooperation=cooperation,
+        )
+
+    def create_interactor_response(
+        self,
+        num_of_plans: int = 0,
+        non_active_plans: list[PlanInfo] | None = None,
+        active_plans: list[PlanInfo] | None = None,
+        expired_plans: list[PlanInfo] | None = None,
+        drafts: list[PlanInfo] | None = None,
+        rejected_plans: list[PlanInfo] | None = None,
+    ) -> ShowMyPlansResponse:
+        if non_active_plans is None:
+            non_active_plans = []
+        if active_plans is None:
+            active_plans = []
+        if expired_plans is None:
+            expired_plans = []
+        if drafts is None:
+            drafts = []
+        if rejected_plans is None:
+            rejected_plans = []
+        return ShowMyPlansResponse(
+            count_all_plans=num_of_plans,
+            non_active_plans=non_active_plans,
+            active_plans=active_plans,
+            expired_plans=expired_plans,
+            drafts=drafts,
+            rejected_plans=rejected_plans,
+        )
+
+
+class ShowMyPlansPresenterTests(PresenterBase):
     def test_show_correct_notification_when_user_has_no_plans(self) -> None:
-        self.presenter.present(
-            ShowMyPlansResponse(
-                count_all_plans=0,
-                non_active_plans=[],
-                active_plans=[],
-                expired_plans=[],
-                drafts=[],
-                rejected_plans=[],
-            )
-        )
-        self.assertTrue(self.notifier.display_info)
-        self.assertEqual(
-            self.notifier.infos,
-            [self.translator.gettext("You don't have any plans.")],
-        )
+        response = self.create_interactor_response(num_of_plans=0)
+        self.presenter.present(response)
+        assert self.notifier.infos == [
+            self.translator.gettext("You don't have any plans.")
+        ]
 
-    def test_do_not_show_notification_when_user_has_one_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record()
-        RESPONSE_WITH_ONE_PLAN = self.response_with_one_plan(plan)
-        self.presenter.present(RESPONSE_WITH_ONE_PLAN)
+    def test_show_no_notification_when_user_has_one_plan(self) -> None:
+        response = self.create_interactor_response(num_of_plans=1)
+        self.presenter.present(response)
         self.assertFalse(self.notifier.infos)
         self.assertFalse(self.notifier.warnings)
 
+
+class ActivePlansTests(PresenterBase):
     def test_do_only_show_active_plans_when_user_has_one_active_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record()
-        RESPONSE_WITH_ONE_ACTIVE_PLAN = self.response_with_one_active_plan(plan)
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_ACTIVE_PLAN)
-        self.assertTrue(presentation.show_active_plans)
-        self.assertFalse(presentation.show_expired_plans)
-        self.assertFalse(presentation.show_non_active_plans)
-        self.assertFalse(presentation.show_rejected_plans)
+        response = self.create_interactor_response(
+            num_of_plans=1, active_plans=[self.create_plan_info()]
+        )
+        presentation = self.presenter.present(response)
+        assert presentation.show_active_plans
+        assert not presentation.show_expired_plans
+        assert not presentation.show_non_active_plans
+        assert not presentation.show_rejected_plans
 
-    def test_presenter_shows_correct_info_of_one_single_active_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record(cooperation=None)
-        RESPONSE_WITH_ONE_ACTIVE_PLAN = self.response_with_one_active_plan(plan)
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_ACTIVE_PLAN)
-        self.assertEqual(
-            presentation.active_plans.rows[0].plan_details_url,
-            self.url_index.get_plan_details_url(
-                user_role=UserRole.company, plan_id=plan.id
-            ),
+    def test_presenter_shows_correct_info_of_active_plan(self) -> None:
+        PLAN_ID = uuid4()
+        PRD_NAME = "Some product name"
+        PRICE_PER_UNIT = Decimal(10)
+        IS_PUBLIC_SERVICE = True
+        response = self.create_interactor_response(
+            active_plans=[
+                self.create_plan_info(
+                    plan_id=PLAN_ID,
+                    prd_name=PRD_NAME,
+                    price_per_unit=PRICE_PER_UNIT,
+                    is_public_service=IS_PUBLIC_SERVICE,
+                )
+            ]
         )
-        self.assertEqual(presentation.active_plans.rows[0].prd_name, plan.prd_name)
-        self.assertEqual(
-            presentation.active_plans.rows[0].price_per_unit,
-            str("10.00"),
+        presentation = self.presenter.present(response)
+        row = presentation.active_plans.rows[0]
+        assert row.plan_details_url == self.url_index.get_plan_details_url(
+            user_role=None, plan_id=PLAN_ID
         )
-        self.assertEqual(
-            presentation.active_plans.rows[0].is_public_service, plan.is_public_service
-        )
-        self.assertEqual(
-            presentation.active_plans.rows[0].is_cooperating,
-            False,
-        )
+        assert row.prd_name == PRD_NAME
+        assert row.price_per_unit == "10.00"
+        assert row.is_public_service == IS_PUBLIC_SERVICE
 
-    def test_presenter_shows_correct_info_of_one_single_plan_that_is_cooperating(
-        self,
+    @parameterized.expand([(True,), (False,)])
+    def test_presenter_shows_correct_cooperating_status_of_active_plan(
+        self, is_cooperating: bool
     ) -> None:
-        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
-        coop = self.coop_generator.create_cooperation()
-        plan = self.plan_generator.create_plan_record(cooperation=coop)
-        RESPONSE_WITH_COOPERATING_PLAN = self.response_with_one_active_plan(
-            plan, cooperation=coop
+        response = self.create_interactor_response(
+            active_plans=[
+                self.create_plan_info(
+                    is_cooperating=is_cooperating,
+                )
+            ]
         )
-        presentation = self.presenter.present(RESPONSE_WITH_COOPERATING_PLAN)
-        self.assertEqual(
-            presentation.active_plans.rows[0].is_cooperating,
-            True,
+        presentation = self.presenter.present(response)
+        assert presentation.active_plans.rows[0].is_cooperating == is_cooperating
+
+    @parameterized.expand([(datetime_utc(2020, 5, 1, 10, 30),), (None,)])
+    def test_presenter_shows_correct_expiration_date_of_active_plan(
+        self, expiration_date: datetime | None
+    ) -> None:
+        response = self.create_interactor_response(
+            active_plans=[
+                self.create_plan_info(
+                    expiration_date=expiration_date,
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        assert (
+            presentation.active_plans.rows[0].expiration_date
+            == expiration_date.strftime("%d.%m.%y")
+            if expiration_date
+            else "–"
         )
 
-    def test_presenter_shows_correct_info_of_one_single_expired_plan(self) -> None:
-        RESPONSE_WITH_ONE_EXPIRED_PLAN = self.response_with_one_expired_plan()
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_EXPIRED_PLAN)
-        row1 = presentation.expired_plans.rows[0]
-        expected_plan = RESPONSE_WITH_ONE_EXPIRED_PLAN.expired_plans[0]
-        self.assertEqual(
-            row1.plan_details_url,
-            self.url_index.get_plan_details_url(
-                user_role=UserRole.company, plan_id=expected_plan.id
-            ),
+    @parameterized.expand([(datetime_utc(2000, 1, 6),), (None,)])
+    def test_that_relative_expiration_is_calculated_correctly_in_days_from_now(
+        self, expiration_date: datetime | None
+    ) -> None:
+        now = datetime_utc(2000, 1, 1)
+        self.datetime_service.freeze_time(now)
+        response = self.create_interactor_response(
+            active_plans=[
+                self.create_plan_info(
+                    expiration_date=expiration_date,
+                )
+            ]
         )
-        self.assertEqual(
-            row1.prd_name,
-            expected_plan.prd_name,
-        )
-        self.assertEqual(row1.is_public_service, expected_plan.is_public_service)
-        self.assertEqual(
-            row1.renew_plan_url,
-            self.url_index.get_renew_plan_url(expected_plan.id),
-        )
-        self.assertEqual(
-            row1.hide_plan_url,
-            self.url_index.get_hide_plan_url(expected_plan.id),
+        view_model = self.presenter.present(response)
+        assert (
+            view_model.active_plans.rows[0].expiration_relative == "5"
+            if expiration_date
+            else "-"
         )
 
-    def test_presenter_shows_correct_info_of_one_single_non_active_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record(approved=False)
-        RESPONSE_WITH_ONE_NON_ACTIVE_PLAN = self.response_with_one_non_active_plan(plan)
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_NON_ACTIVE_PLAN)
-        row1 = presentation.non_active_plans.rows[0]
-        expected_plan = RESPONSE_WITH_ONE_NON_ACTIVE_PLAN.non_active_plans[0]
+
+class ExpiredPlansTests(PresenterBase):
+    def test_presenter_shows_correct_info_of_expired_plan(self) -> None:
+        PLAN_ID = uuid4()
+        PRD_NAME = "Some product name"
+        IS_PUBLIC_SERVICE = True
+        response = self.create_interactor_response(
+            expired_plans=[
+                self.create_plan_info(
+                    plan_id=PLAN_ID,
+                    prd_name=PRD_NAME,
+                    is_public_service=IS_PUBLIC_SERVICE,
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        row = presentation.expired_plans.rows[0]
         self.assertEqual(
-            row1.plan_details_url,
-            self.url_index.get_plan_details_url(
-                user_role=UserRole.company, plan_id=plan.id
-            ),
+            row.plan_details_url,
+            self.url_index.get_plan_details_url(user_role=None, plan_id=PLAN_ID),
         )
         self.assertEqual(
-            row1.prd_name,
-            expected_plan.prd_name,
+            row.prd_name,
+            PRD_NAME,
+        )
+        self.assertEqual(row.is_public_service, IS_PUBLIC_SERVICE)
+        self.assertEqual(
+            row.renew_plan_url,
+            self.url_index.get_renew_plan_url(PLAN_ID),
         )
         self.assertEqual(
-            row1.price_per_unit,
-            "10.00",
+            row.hide_plan_url,
+            self.url_index.get_hide_plan_url(PLAN_ID),
         )
-        self.assertEqual(row1.type_of_plan, self.translator.gettext("Productive"))
+
+
+class NonActivePlansTests(PresenterBase):
+    def test_presenter_shows_correct_info_of_non_active_plan(self) -> None:
+        PLAN_ID = uuid4()
+        PRD_NAME = "Some product name"
+        PRICE_PER_UNIT = Decimal(22)
+        response = self.create_interactor_response(
+            non_active_plans=[
+                self.create_plan_info(
+                    plan_id=PLAN_ID, prd_name=PRD_NAME, price_per_unit=PRICE_PER_UNIT
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        row = presentation.non_active_plans.rows[0]
+        self.assertEqual(
+            row.plan_details_url,
+            self.url_index.get_plan_details_url(user_role=None, plan_id=PLAN_ID),
+        )
+        self.assertEqual(
+            row.prd_name,
+            PRD_NAME,
+        )
+        self.assertEqual(
+            row.price_per_unit,
+            str(round(PRICE_PER_UNIT, 2)),
+        )
+
+    @parameterized.expand([(True,), (False,)])
+    def test_presenter_converts_public_status_of_non_active_plan_in_correct_string(
+        self, is_public_service: bool
+    ) -> None:
+        response = self.create_interactor_response(
+            non_active_plans=[
+                self.create_plan_info(is_public_service=is_public_service)
+            ]
+        )
+        presentation = self.presenter.present(response)
+        assert (
+            presentation.non_active_plans.rows[0].type_of_plan
+            == self.translator.gettext("Public")
+            if is_public_service
+            else self.translator.gettext("Productive")
+        )
 
     def test_non_active_plan_has_correct_revocation_url(self) -> None:
-        plan = self.plan_generator.create_plan_record(approved=False)
-        interactor_response = self.response_with_one_non_active_plan(plan)
-        view_model = self.presenter.present(interactor_response)
+        PLAN_ID = uuid4()
+        response = self.create_interactor_response(
+            non_active_plans=[
+                self.create_plan_info(
+                    plan_id=PLAN_ID,
+                )
+            ]
+        )
+        view_model = self.presenter.present(response)
         row = view_model.non_active_plans.rows[0]
         self.assertEqual(
             row.revoke_plan_filing_url,
-            self.url_index.get_revoke_plan_filing_url(plan.id),
+            self.url_index.get_revoke_plan_filing_url(PLAN_ID),
         )
 
-    def test_that_relative_expiration_is_calculated_correctly(self) -> None:
-        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
-        plan = self._create_active_plan(timeframe=5)
-        view_model = self.presenter.present(self.response_with_one_active_plan(plan))
-        self.assertEqual(
-            view_model.active_plans.rows[0].expiration_relative,
-            "5",
-        )
 
+class DraftsTests(PresenterBase):
     def test_that_drafts_are_not_shown_when_no_draft_is_in_response(self) -> None:
-        response = self.response_with_no_plans()
+        response = self.create_interactor_response()
         view_model = self.presenter.present(response)
         self.assertFalse(view_model.show_drafts)
 
     def test_drafts_are_displayed_if_one_is_in_response(self) -> None:
-        response = self.response_with_one_draft()
+        response = self.create_interactor_response(drafts=[self.create_plan_info()])
         view_model = self.presenter.present(response)
         self.assertTrue(view_model.show_drafts)
 
     def test_that_draft_prd_name_is_filled_in_correctly(self) -> None:
-        expected_name = "test product name"
-        response = self.response_with_one_draft(product_name=expected_name)
+        PRD_NAME = "test product name"
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(prd_name=PRD_NAME)]
+        )
         view_model = self.presenter.present(response)
-        self.assertEqual(view_model.drafts.rows[0].product_name, expected_name)
+        self.assertEqual(view_model.drafts.rows[0].product_name, PRD_NAME)
 
     def test_that_draft_creation_date_is_filled_in_correctly(self) -> None:
-        expected_creation_time = datetime_utc(2020, 5, 1)
-        self.datetime_service.freeze_time(expected_creation_time)
-        response = self.response_with_one_draft()
+        CREATION_DATE = datetime_utc(2020, 5, 1)
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(plan_creation_date=CREATION_DATE)]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(view_model.drafts.rows[0].draft_creation_date, "01.05.20")
 
     def test_that_draft_details_url_is_set_correctly(self) -> None:
-        response = self.response_with_one_draft()
-        draft_id = response.drafts[0].id
+        DRAFT_ID = uuid4()
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(plan_id=DRAFT_ID)]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.drafts.rows[0].draft_details_url,
-            self.url_index.get_draft_details_url(draft_id),
+            self.url_index.get_draft_details_url(DRAFT_ID),
         )
 
     def test_that_delete_draft_url_is_set_correctly(self) -> None:
-        response = self.response_with_one_draft()
-        draft_id = response.drafts[0].id
+        DRAFT_ID = uuid4()
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(plan_id=DRAFT_ID)]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.drafts.rows[0].draft_delete_url,
-            self.url_index.get_delete_draft_url(draft_id),
+            self.url_index.get_delete_draft_url(DRAFT_ID),
         )
 
     def test_that_file_plan_url_is_set_correctly(self) -> None:
-        response = self.response_with_one_draft()
-        draft_id = response.drafts[0].id
+        DRAFT_ID = uuid4()
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(plan_id=DRAFT_ID)]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.drafts.rows[0].file_plan_url,
-            self.url_index.get_file_plan_url(draft_id),
+            self.url_index.get_file_plan_url(DRAFT_ID),
         )
 
     def test_that_edit_plan_url_is_set_correctly(self) -> None:
-        response = self.response_with_one_draft()
-        draft_id = response.drafts[0].id
+        DRAFT_ID = uuid4()
+        response = self.create_interactor_response(
+            drafts=[self.create_plan_info(plan_id=DRAFT_ID)]
+        )
         view_model = self.presenter.present(response)
         self.assertEqual(
             view_model.drafts.rows[0].edit_plan_url,
-            self.url_index.get_draft_details_url(draft_id),
+            self.url_index.get_draft_details_url(DRAFT_ID),
         )
 
+
+class RejectedPlansTests(PresenterBase):
     def test_do_only_show_rejected_plans_when_user_has_one_rejected_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record()
-        RESPONSE_WITH_ONE_REJECTED_PLAN = self.response_with_one_rejected_plan(plan)
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_REJECTED_PLAN)
+        response = self.create_interactor_response(
+            rejected_plans=[self.create_plan_info()]
+        )
+        presentation = self.presenter.present(response)
         self.assertTrue(presentation.show_rejected_plans)
         self.assertFalse(presentation.show_expired_plans)
         self.assertFalse(presentation.show_non_active_plans)
         self.assertFalse(presentation.show_active_plans)
 
     def test_presenter_shows_correct_info_of_one_single_rejected_plan(self) -> None:
-        plan = self.plan_generator.create_plan_record(cooperation=None)
-        RESPONSE_WITH_ONE_REJECTED_PLAN = self.response_with_one_rejected_plan(plan)
-        presentation = self.presenter.present(RESPONSE_WITH_ONE_REJECTED_PLAN)
+        PLAN_ID = uuid4()
+        PRD_NAME = "Some product name"
+        PRICE_PER_UNIT = Decimal(33)
+        IS_PUBLIC_SERVICE = True
+        response = self.create_interactor_response(
+            rejected_plans=[
+                self.create_plan_info(
+                    plan_id=PLAN_ID,
+                    prd_name=PRD_NAME,
+                    price_per_unit=PRICE_PER_UNIT,
+                    is_public_service=IS_PUBLIC_SERVICE,
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        row = presentation.rejected_plans.rows[0]
         self.assertEqual(
-            presentation.rejected_plans.rows[0].plan_details_url,
-            self.url_index.get_plan_details_url(
-                user_role=UserRole.company, plan_id=plan.id
-            ),
+            row.plan_details_url,
+            self.url_index.get_plan_details_url(user_role=None, plan_id=PLAN_ID),
         )
-        self.assertEqual(presentation.rejected_plans.rows[0].prd_name, plan.prd_name)
+        self.assertEqual(row.prd_name, PRD_NAME)
         self.assertEqual(
-            presentation.rejected_plans.rows[0].price_per_unit,
-            str("10.00"),
+            row.price_per_unit,
+            str(round(PRICE_PER_UNIT, 2)),
         )
         self.assertEqual(
-            presentation.rejected_plans.rows[0].is_public_service,
-            plan.is_public_service,
+            row.is_public_service,
+            IS_PUBLIC_SERVICE,
         )
-
-    def _convert_into_plan_info(
-        self, plan: Plan, cooperation: UUID | None = None
-    ) -> PlanInfo:
-        return PlanInfo(
-            id=plan.id,
-            prd_name=plan.prd_name,
-            price_per_unit=Decimal("10.001"),
-            is_public_service=plan.is_public_service,
-            plan_creation_date=plan.plan_creation_date,
-            approval_date=plan.approval_date,
-            expiration_date=plan.expiration_date,
-            is_cooperating=bool(cooperation),
-            cooperation=cooperation,
-            rejection_date=plan.rejection_date,
-        )
-
-    def _convert_draft_into_plan_info(self, plan: PlanDraft) -> PlanInfo:
-        return PlanInfo(
-            id=plan.id,
-            prd_name=plan.product_name,
-            price_per_unit=plan.production_costs.total_cost() / plan.amount_produced,
-            is_public_service=plan.is_public_service,
-            plan_creation_date=plan.creation_date,
-            approval_date=None,
-            expiration_date=None,
-            is_cooperating=False,
-            cooperation=None,
-            rejection_date=None,
-        )
-
-    def response_with_one_draft(
-        self, *, product_name: str = "test name"
-    ) -> ShowMyPlansResponse:
-        planner = self.company_generator.create_company()
-        self.plan_generator.draft_plan(
-            product_name=product_name, timeframe=1, planner=planner
-        )
-        self.datetime_service.advance_time(timedelta(days=2))
-        return self.show_my_plans.show_company_plans(
-            request=ShowMyPlansRequest(company_id=planner)
-        )
-
-    def response_with_no_plans(self) -> ShowMyPlansResponse:
-        return ShowMyPlansResponse(
-            count_all_plans=0,
-            non_active_plans=[],
-            active_plans=[],
-            expired_plans=[],
-            drafts=[],
-            rejected_plans=[],
-        )
-
-    def response_with_one_plan(self, plan: Plan) -> ShowMyPlansResponse:
-        plan_info = self._convert_into_plan_info(plan)
-        return ShowMyPlansResponse(
-            count_all_plans=1,
-            non_active_plans=[],
-            active_plans=[plan_info],
-            expired_plans=[],
-            drafts=[],
-            rejected_plans=[],
-        )
-
-    def response_with_one_active_plan(
-        self, plan: Plan, cooperation: UUID | None = None
-    ) -> ShowMyPlansResponse:
-        plan_info = self._convert_into_plan_info(plan, cooperation)
-        return ShowMyPlansResponse(
-            count_all_plans=1,
-            non_active_plans=[],
-            active_plans=[plan_info],
-            expired_plans=[],
-            drafts=[],
-            rejected_plans=[],
-        )
-
-    def response_with_one_expired_plan(self) -> ShowMyPlansResponse:
-        planner = self.company_generator.create_company()
-        self.plan_generator.create_plan_record(planner=planner, timeframe=1)
-        self.datetime_service.advance_time(timedelta(days=2))
-        return self.show_my_plans.show_company_plans(
-            request=ShowMyPlansRequest(company_id=planner)
-        )
-
-    def response_with_one_non_active_plan(self, plan: Plan) -> ShowMyPlansResponse:
-        plan_info = self._convert_into_plan_info(plan)
-        return ShowMyPlansResponse(
-            count_all_plans=1,
-            non_active_plans=[plan_info],
-            active_plans=[],
-            expired_plans=[],
-            drafts=[],
-            rejected_plans=[],
-        )
-
-    def response_with_one_rejected_plan(self, plan: Plan) -> ShowMyPlansResponse:
-        plan_info = self._convert_into_plan_info(plan)
-        return ShowMyPlansResponse(
-            count_all_plans=1,
-            non_active_plans=[],
-            active_plans=[],
-            expired_plans=[],
-            drafts=[],
-            rejected_plans=[plan_info],
-        )
-
-    def _create_active_plan(self, timeframe: int = 1) -> Plan:
-        plan = self.plan_generator.create_plan_record(
-            timeframe=timeframe,
-        )
-        return plan


### PR DESCRIPTION
This PR consists of several commits. The main goal was to reduce the dependency of our tests from complex business logic objects (records) - in this case the `Plan` record. This dependency has been replaced with a dependency on the plan id. This was done to protect our tests from changes in the business records.

Along the way there has been some refactoring, a slight change in how the cooperation price is calculated and a well-hidden bug in the Plan repository has been fixed.