### PR TITLE
Introduce new price calculcation method

### DIFF
--- a/arbeitszeit/interactors/get_coop_summary.py
+++ b/arbeitszeit/interactors/get_coop_summary.py
@@ -81,7 +81,7 @@ class GetCoopSummaryInteractor:
     def _get_cooperative_price(self, plans: list[Plan]) -> Optional[Decimal]:
         if not plans:
             return None
-        return self.price_calculator.calculate_cooperative_price(plans[0].id)
+        return self.price_calculator.calculate_price(plans[0].id)
 
     def _get_associated_plans(
         self, plans: list[Plan], requester: UUID
@@ -90,7 +90,7 @@ class GetCoopSummaryInteractor:
             AssociatedPlan(
                 plan_id=plan.id,
                 plan_name=plan.prd_name,
-                plan_individual_price=plan.price_per_unit(),
+                plan_individual_price=plan.cost_per_unit(),
                 planner_id=plan.planner,
                 planner_name=self._get_planner_name(plan.planner),
                 requester_is_planner=plan.planner == requester,

--- a/arbeitszeit/interactors/query_company_consumptions.py
+++ b/arbeitszeit/interactors/query_company_consumptions.py
@@ -21,7 +21,7 @@ class ConsumptionQueryResponse:
     product_name: str
     product_description: str
     consumption_type: ConsumptionType
-    price_per_unit: Decimal
+    paid_price_per_unit: Decimal
     amount: int
 
 
@@ -63,6 +63,6 @@ class QueryCompanyConsumptionsInteractor:
             product_name=plan.prd_name,
             product_description=plan.description,
             consumption_type=consumption_type,
-            price_per_unit=transfer.value / consumption.amount,
+            paid_price_per_unit=transfer.value / consumption.amount,
             amount=consumption.amount,
         )

--- a/arbeitszeit/interactors/query_plans.py
+++ b/arbeitszeit/interactors/query_plans.py
@@ -106,9 +106,7 @@ class QueryPlansInteractor:
         planner: records.Company,
         cooperation: Optional[records.Cooperation],
     ) -> QueriedPlan:
-        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
-        if price_per_unit is None:
-            price_per_unit = plan.price_per_unit()
+        price_per_unit = self.price_calculator.calculate_price(plan.id)
         assert plan.approval_date
         return QueriedPlan(
             plan_id=plan.id,

--- a/arbeitszeit/interactors/query_private_consumptions.py
+++ b/arbeitszeit/interactors/query_private_consumptions.py
@@ -13,9 +13,9 @@ class Consumption:
     plan_id: UUID
     product_name: str
     product_description: str
-    price_per_unit: Decimal
+    paid_price_per_unit: Decimal
     amount: int
-    price_total: Decimal
+    paid_price_total: Decimal
 
 
 @dataclass
@@ -53,7 +53,7 @@ class QueryPrivateConsumptions:
             plan_id=plan.id,
             product_name=plan.prd_name,
             product_description=plan.description,
-            price_per_unit=transfer.value / consumption.amount,
+            paid_price_per_unit=transfer.value / consumption.amount,
             amount=consumption.amount,
-            price_total=transfer.value,
+            paid_price_total=transfer.value,
         )

--- a/arbeitszeit/interactors/register_private_consumption.py
+++ b/arbeitszeit/interactors/register_private_consumption.py
@@ -59,19 +59,17 @@ class RegisterPrivateConsumption:
     ) -> RegisterPrivateConsumptionResponse:
         plan, planner = self._get_plan_and_planner(request)
         consumer = self._get_consumer(request)
-        coop_price = self.price_calculator.calculate_cooperative_price(plan.id)
-        if coop_price is None:
-            coop_price = plan.price_per_unit()
+        price_per_unit = self.price_calculator.calculate_price(plan.id)
         consumption_transfer = self._create_private_consumption_transfer(
             debit_account=consumer.account,
             credit_account=planner.product_account,
-            value=coop_price * request.amount,
+            value=price_per_unit * request.amount,
         )
         compensation_transfer = self._get_compensation_transfer_if_any(
             plan_id=plan.id,
             planner_product_account=planner.product_account,
-            plan_price_per_unit=plan.price_per_unit(),
-            coop_price_per_unit=coop_price,
+            cost_per_unit=plan.cost_per_unit(),
+            price_per_unit=price_per_unit,
             consumed_amount=request.amount,
         )
         self.database_gateway.create_private_consumption(
@@ -155,16 +153,16 @@ class RegisterPrivateConsumption:
         self,
         plan_id: UUID,
         planner_product_account: UUID,
-        plan_price_per_unit: Decimal,
-        coop_price_per_unit: Decimal,
+        cost_per_unit: Decimal,
+        price_per_unit: Decimal,
         consumed_amount: int,
     ) -> UUID | None:
         cooperation = self.database_gateway.get_cooperations().of_plan(plan_id).first()
         if not cooperation:
             return None
         return self.compensation_transfer_service.create_compensation_transfer(
-            coop_price_per_unit=coop_price_per_unit,
-            plan_price_per_unit=plan_price_per_unit,
+            price_per_unit=price_per_unit,
+            cost_per_unit=cost_per_unit,
             consumed_amount=consumed_amount,
             planner_product_account=planner_product_account,
             cooperation_account=cooperation.account,

--- a/arbeitszeit/interactors/show_my_plans.py
+++ b/arbeitszeit/interactors/show_my_plans.py
@@ -103,9 +103,7 @@ class ShowMyPlansInteractor:
     def _create_plan_info_from_plan(
         self, plan: records.Plan, cooperation: Optional[records.Cooperation]
     ) -> PlanInfo:
-        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
-        if price_per_unit is None:
-            price_per_unit = plan.price_per_unit()
+        price_per_unit = self.price_calculator.calculate_price(plan.id)
         return PlanInfo(
             id=plan.id,
             prd_name=plan.prd_name,

--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -234,9 +234,6 @@ class Plan:
             return Decimal(0)
         return self.production_costs.total_cost() / Decimal(self.prd_amount)
 
-    def price_per_unit(self) -> Decimal:
-        return Decimal(0) if self.is_public_service else self.cost_per_unit()
-
 
 @dataclass
 class PlanApproval:

--- a/arbeitszeit/services/compensation_transfers.py
+++ b/arbeitszeit/services/compensation_transfers.py
@@ -18,13 +18,13 @@ class CompensationTransferService:
 
     def create_compensation_transfer(
         self,
-        coop_price_per_unit: Decimal,
-        plan_price_per_unit: Decimal,
+        price_per_unit: Decimal,
+        cost_per_unit: Decimal,
         consumed_amount: int,
         planner_product_account: UUID,
         cooperation_account: UUID,
     ) -> UUID | None:
-        difference = coop_price_per_unit - plan_price_per_unit
+        difference = price_per_unit - cost_per_unit
         if not difference:
             return None
         elif difference < Decimal(0):

--- a/arbeitszeit/services/plan_details.py
+++ b/arbeitszeit/services/plan_details.py
@@ -26,7 +26,7 @@ class PlanDetails:
     labour_cost: Decimal
     is_public_service: bool
     price_per_unit: Decimal
-    labour_cost_per_unit: Decimal
+    cost_per_unit: Decimal
     is_cooperating: bool
     cooperation: Optional[UUID]
     creation_date: datetime
@@ -51,9 +51,7 @@ class PlanDetailsService:
         if not plan_and_cooperation:
             return None
         plan, cooperation = plan_and_cooperation
-        price_per_unit = self.price_calculator.calculate_cooperative_price(plan.id)
-        if price_per_unit is None:
-            price_per_unit = plan.price_per_unit()
+        price_per_unit = self.price_calculator.calculate_price(plan.id)
         planner = self.database_gateway.get_companies().with_id(plan.planner).first()
         assert planner
         return PlanDetails(
@@ -72,7 +70,7 @@ class PlanDetailsService:
             labour_cost=plan.production_costs.labour_cost,
             is_public_service=plan.is_public_service,
             price_per_unit=price_per_unit,
-            labour_cost_per_unit=plan.cost_per_unit(),
+            cost_per_unit=plan.cost_per_unit(),
             is_cooperating=bool(cooperation),
             cooperation=cooperation.id if cooperation else None,
             creation_date=plan.plan_creation_date,

--- a/arbeitszeit_web/formatters/plan_details_formatter.py
+++ b/arbeitszeit_web/formatters/plan_details_formatter.py
@@ -108,7 +108,7 @@ class PlanDetailsFormatter:
             ),
             labour_cost_per_unit=(
                 self.translator.gettext("Labour time (hours/unit)"),
-                self._format_price(plan_details.labour_cost_per_unit),
+                self._format_price(plan_details.cost_per_unit),
             ),
             creation_date=self.datetime_formatter.format_datetime(
                 date=plan_details.creation_date,

--- a/arbeitszeit_web/www/presenters/company_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/company_consumptions_presenter.py
@@ -50,9 +50,11 @@ class CompanyConsumptionsPresenter:
             consumption_type=self._format_consumption_type(
                 consumption.consumption_type
             ),
-            price_per_unit=str(round(consumption.price_per_unit, 2)),
+            price_per_unit=str(round(consumption.paid_price_per_unit, 2)),
             amount=str(consumption.amount),
-            price_total=str(round(consumption.price_per_unit * consumption.amount, 2)),
+            price_total=str(
+                round(consumption.paid_price_per_unit * consumption.amount, 2)
+            ),
         )
 
     def _format_consumption_type(self, consumption_type: ConsumptionType) -> str:

--- a/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
@@ -34,9 +34,9 @@ class PrivateConsumptionsPresenter:
                     ),
                     product_name=consumption.product_name,
                     product_description=consumption.product_description,
-                    price_per_unit=str(consumption.price_per_unit),
+                    price_per_unit=str(consumption.paid_price_per_unit),
                     consumption_amount=str(consumption.amount),
-                    price_total=str(consumption.price_total),
+                    price_total=str(consumption.paid_price_total),
                 )
                 for consumption in response.consumptions
             ],

--- a/tests/interactors/price_checker.py
+++ b/tests/interactors/price_checker.py
@@ -9,23 +9,14 @@ from arbeitszeit.interactors.get_plan_details import GetPlanDetailsInteractor
 class PriceChecker:
     get_plan_details: GetPlanDetailsInteractor
 
-    def get_unit_price(self, plan: UUID) -> Decimal:
+    def get_price_per_unit(self, plan: UUID) -> Decimal:
         request = GetPlanDetailsInteractor.Request(plan)
         response = self.get_plan_details.get_plan_details(request)
         assert response
         return response.plan_details.price_per_unit
 
-    def get_labour_per_unit(self, plan: UUID) -> Decimal:
+    def get_cost_per_unit(self, plan: UUID) -> Decimal:
         request = GetPlanDetailsInteractor.Request(plan)
         response = self.get_plan_details.get_plan_details(request)
         assert response
-        return response.plan_details.labour_cost_per_unit
-
-    def get_unit_cost(self, plan: UUID) -> Decimal:
-        request = GetPlanDetailsInteractor.Request(plan)
-        response = self.get_plan_details.get_plan_details(request)
-        assert response
-        details = response.plan_details
-        return (
-            details.means_cost + details.resources_cost + details.labour_cost
-        ) / details.amount
+        return response.plan_details.cost_per_unit

--- a/tests/interactors/test_accept_cooperation.py
+++ b/tests/interactors/test_accept_cooperation.py
@@ -155,9 +155,9 @@ class AcceptCooperationTests(BaseTestCase):
         )
         self.accept_cooperation.execute(request1)
         self.accept_cooperation.execute(request2)
-        assert self.price_checker.get_unit_price(
+        assert self.price_checker.get_price_per_unit(
             plan1
-        ) == self.price_checker.get_unit_price(plan2)
+        ) == self.price_checker.get_price_per_unit(plan2)
 
     def test_price_of_cooperating_plans_is_correctly_calculated(self) -> None:
         requester = self.company_generator.create_company_record()
@@ -184,8 +184,8 @@ class AcceptCooperationTests(BaseTestCase):
         self.accept_cooperation.execute(request2)
         # In total costs of 30h and 20 units -> price should be 1.5h per unit
         assert (
-            self.price_checker.get_unit_price(plan1)
-            == self.price_checker.get_unit_price(plan2)
+            self.price_checker.get_price_per_unit(plan1)
+            == self.price_checker.get_price_per_unit(plan2)
             == Decimal("1.5")
         )
 

--- a/tests/interactors/test_query_plans.py
+++ b/tests/interactors/test_query_plans.py
@@ -281,7 +281,7 @@ class InteractorTests(BaseTestCase):
         response = self.interactor.execute(self.make_request())
         assert response.results[0].price_per_unit == 0
 
-    def test_that_labour_per_unit_is_correctly_displayed(
+    def test_that_cost_per_unit_is_correctly_displayed(
         self,
     ) -> None:
         plan = self.plan_generator.create_plan(
@@ -295,7 +295,7 @@ class InteractorTests(BaseTestCase):
         queried_plan = response.results[0]
         assert (
             queried_plan.labour_cost_per_unit
-            == self.price_checker.get_labour_per_unit(plan)
+            == self.price_checker.get_cost_per_unit(plan)
         )
 
     def test_that_two_cooperating_plans_have_the_same_price(self) -> None:
@@ -318,12 +318,12 @@ class InteractorTests(BaseTestCase):
             amount=1,
         )
         response = self.interactor.execute(self.make_request())
-        assert response.results[0].price_per_unit == self.price_checker.get_unit_price(
-            plan1
-        )
-        assert response.results[1].price_per_unit == self.price_checker.get_unit_price(
-            plan2
-        )
+        assert response.results[
+            0
+        ].price_per_unit == self.price_checker.get_price_per_unit(plan1)
+        assert response.results[
+            1
+        ].price_per_unit == self.price_checker.get_price_per_unit(plan2)
 
     @parameterized.expand(
         [

--- a/tests/interactors/test_register_private_consumption.py
+++ b/tests/interactors/test_register_private_consumption.py
@@ -221,7 +221,7 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         self.register_private_consumption.register_private_consumption(
             self.make_request(plan, pieces_consumed)
         )
-        costs = pieces_consumed * self.price_checker.get_unit_price(plan)
+        costs = pieces_consumed * self.price_checker.get_price_per_unit(plan)
         expected_balance = start_balance - costs
         assert (
             self.balance_checker.get_member_account_balance(self.consumer)
@@ -239,7 +239,7 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         self.register_private_consumption.register_private_consumption(
             self.make_request(plan, pieces)
         )
-        costs = pieces * self.price_checker.get_unit_price(plan)
+        costs = pieces * self.price_checker.get_price_per_unit(plan)
         assert self.balance_checker.get_member_account_balance(self.consumer) == -costs
         assert (
             self.balance_checker.get_company_account_balances(planner).prd_account
@@ -258,8 +258,9 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         )
         assert len(response.consumptions) == 1
         latest_consumption = response.consumptions[0]
-        assert latest_consumption.price_per_unit == self.price_checker.get_unit_price(
-            plan
+        assert (
+            latest_consumption.paid_price_per_unit
+            == self.price_checker.get_price_per_unit(plan)
         )
         assert latest_consumption.amount == pieces
         assert latest_consumption.plan_id == plan
@@ -275,7 +276,7 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         )
         assert len(response.consumptions) == 1
         latest_consumption = response.consumptions[0]
-        assert latest_consumption.price_per_unit == Decimal(0)
+        assert latest_consumption.paid_price_per_unit == Decimal(0)
         assert latest_consumption.plan_id == plan
 
     def make_request(

--- a/tests/interactors/test_register_productive_consumption.py
+++ b/tests/interactors/test_register_productive_consumption.py
@@ -111,7 +111,7 @@ class TestBalanceChanges(InteractorBase):
             RegisterProductiveConsumptionRequest(sender, plan, pieces, consumption_type)
         )
 
-        price_total = pieces * self.price_checker.get_unit_price(plan)
+        price_total = pieces * self.price_checker.get_price_per_unit(plan)
         assert (
             self.balance_checker.get_company_account_balances(sender).p_account
             == -price_total
@@ -127,7 +127,7 @@ class TestBalanceChanges(InteractorBase):
             RegisterProductiveConsumptionRequest(sender, plan, pieces, consumption_type)
         )
 
-        price_total = pieces * self.price_checker.get_unit_price(plan)
+        price_total = pieces * self.price_checker.get_price_per_unit(plan)
         assert (
             self.balance_checker.get_company_account_balances(sender).r_account
             == -price_total
@@ -177,7 +177,7 @@ class TestBalanceChanges(InteractorBase):
         )
         assert (
             self.balance_checker.get_company_account_balances(planner).prd_account
-            == balance_before_transfer + self.price_checker.get_unit_cost(plan) * 5
+            == balance_before_transfer + self.price_checker.get_cost_per_unit(plan) * 5
         )
 
     def test_that_unit_cost_for_cooperating_plans_only_considers_non_expired_plans(
@@ -228,7 +228,7 @@ class TestConsumptionTransfers(InteractorBase):
             plan=plan,
             amount=amount,
         )
-        expected_value = amount * self.price_checker.get_unit_price(plan)
+        expected_value = amount * self.price_checker.get_price_per_unit(plan)
         transfers_of_consumption_p = self._get_transfers_of_type(
             TransferType.productive_consumption_p
         )
@@ -267,7 +267,7 @@ class TestConsumptionTransfers(InteractorBase):
             plan=plan_1,
             amount=AMOUNT,
         )
-        expected_value = AMOUNT * self.price_checker.get_unit_price(plan_1)
+        expected_value = AMOUNT * self.price_checker.get_price_per_unit(plan_1)
         transfers_of_consumption_p = self._get_transfers_of_type(
             TransferType.productive_consumption_p
         )
@@ -286,7 +286,7 @@ class TestConsumptionTransfers(InteractorBase):
             plan=plan,
             amount=amount,
         )
-        expected_value = amount * self.price_checker.get_unit_price(plan)
+        expected_value = amount * self.price_checker.get_price_per_unit(plan)
         transfers_of_consumption_r = self._get_transfers_of_type(
             TransferType.productive_consumption_r
         )
@@ -324,7 +324,7 @@ class TestConsumptionTransfers(InteractorBase):
         self.consumption_generator.create_resource_consumption_by_company(
             plan=plan_1, amount=AMOUNT
         )
-        expected_value = self.price_checker.get_unit_price(plan_1) * AMOUNT
+        expected_value = self.price_checker.get_price_per_unit(plan_1) * AMOUNT
         transfers_of_consumption_r = self._get_transfers_of_type(
             TransferType.productive_consumption_r
         )

--- a/tests/services/test_compensation_transfer_service.py
+++ b/tests/services/test_compensation_transfer_service.py
@@ -19,8 +19,8 @@ class CompensationTransferServiceTests(BaseTestCase):
         self,
     ) -> None:
         self.service.create_compensation_transfer(
-            coop_price_per_unit=Decimal(3),
-            plan_price_per_unit=Decimal(3),
+            price_per_unit=Decimal(3),
+            cost_per_unit=Decimal(3),
             consumed_amount=1,
             cooperation_account=uuid4(),
             planner_product_account=uuid4(),
@@ -50,8 +50,8 @@ class CompensationTransferServiceTests(BaseTestCase):
         )
         self.datetime_service.freeze_time(EXPECTED_TIME)
         self.service.create_compensation_transfer(
-            coop_price_per_unit=coop_price_per_unit,
-            plan_price_per_unit=plan_price_per_unit,
+            price_per_unit=coop_price_per_unit,
+            cost_per_unit=plan_price_per_unit,
             consumed_amount=consumed_amount,
             cooperation_account=EXPECTED_CREDIT_ACCOUNT,
             planner_product_account=EXPECTED_DEBIT_ACCOUNT,
@@ -87,8 +87,8 @@ class CompensationTransferServiceTests(BaseTestCase):
         )
         self.datetime_service.freeze_time(EXPECTED_TIME)
         self.service.create_compensation_transfer(
-            coop_price_per_unit=coop_price_per_unit,
-            plan_price_per_unit=plan_price_per_unit,
+            price_per_unit=coop_price_per_unit,
+            cost_per_unit=plan_price_per_unit,
             consumed_amount=consumed_amount,
             cooperation_account=EXPECTED_DEBIT_ACCOUNT,
             planner_product_account=EXPECTED_CREDIT_ACCOUNT,

--- a/tests/services/test_plan_details_service.py
+++ b/tests/services/test_plan_details_service.py
@@ -96,7 +96,7 @@ class PlanDetailsServiceTests(TestCase):
             (False, False),
         ]
     )
-    def test_that_correct_labour_per_unit_is_shown(
+    def test_that_correct_cost_per_unit_is_shown(
         self, is_public_service: bool, approved: bool
     ) -> None:
         plan = self.plan_generator.create_plan(
@@ -111,7 +111,7 @@ class PlanDetailsServiceTests(TestCase):
         )
         details = self.service.get_details_from_plan(plan)
         assert details
-        self.assertEqual(details.labour_cost_per_unit, Decimal(3))
+        self.assertEqual(details.cost_per_unit, Decimal(3))
 
     @parameterized.expand(
         [

--- a/tests/services/test_price_calculator.py
+++ b/tests/services/test_price_calculator.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from uuid import uuid4
 
 from parameterized import parameterized
 
@@ -10,17 +11,49 @@ from tests.interactors.base_test_case import BaseTestCase
 class PriceCalculatorTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.calculator = self.injector.get(PriceCalculator)
+        self.service = self.injector.get(PriceCalculator)
 
-    def test_that_service_returns_none_for_noncooperating_public_plan(self) -> None:
-        plan = self.plan_generator.create_plan(is_public_service=True)
-        price = self.calculator.calculate_cooperative_price(plan)
-        assert price is None
+    def test_price_is_zero_for_nonexisting_plan(self) -> None:
+        assert self.service.calculate_price(uuid4()) == 0
 
-    def test_that_service_returns_none_for_noncooperating_productive_plan(self) -> None:
-        plan = self.plan_generator.create_plan(is_public_service=False)
-        price = self.calculator.calculate_cooperative_price(plan)
-        assert price is None
+    def test_price_is_zero_for_public_plan(self) -> None:
+        plan = self.plan_generator.create_plan(
+            is_public_service=True,
+            costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)),
+        )
+        price = self.service.calculate_price(plan)
+        assert price == 0
+
+    @parameterized.expand(
+        [
+            (
+                Decimal(0),
+                0,
+            ),
+            (
+                Decimal(10),
+                0,
+            ),
+            (
+                Decimal(10),
+                5,
+            ),
+            (Decimal(0), 2),
+        ]
+    )
+    def test_price_equals_cost_per_unit_if_productive_plan_is_not_cooperating(
+        self,
+        costs: Decimal,
+        units: int,
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            costs=ProductionCosts(costs / 3, costs / 3, costs / 3),
+            amount=units,
+            is_public_service=False,
+            cooperation=None,
+        )
+        price = self.service.calculate_price(plan)
+        assert price == (costs / units if units else Decimal(0))
 
     def test_that_price_is_zero_when_all_plans_in_cooperation_produce_zero_units(
         self,
@@ -36,9 +69,9 @@ class PriceCalculatorTests(BaseTestCase):
         self.cooperation_generator.create_cooperation(
             plans=[plan_1, plan_2],
         )
-        price = self.calculator.calculate_cooperative_price(plan_1)
-        assert price is not None
-        assert price == Decimal(0)
+        price1 = self.service.calculate_price(plan_1)
+        price2 = self.service.calculate_price(plan_2)
+        assert price1 == price2 == 0
 
     @parameterized.expand(
         [
@@ -55,22 +88,21 @@ class PriceCalculatorTests(BaseTestCase):
             amount=1,
         )
         self.cooperation_generator.create_cooperation(plans=[plan])
-        price = self.calculator.calculate_cooperative_price(plan)
-        assert price is not None
-        self.assertAlmostEqual(price, costs)
+        price = self.service.calculate_price(plan)
+        assert price == costs
 
     @parameterized.expand(
         [
-            (Decimal(10), Decimal(20), Decimal(15)),
-            (Decimal(20), Decimal(30), Decimal(25)),
+            (Decimal(10), Decimal(20)),
+            (Decimal(20), Decimal(30)),
         ]
     )
     def test_that_cooperative_price_for_two_companies_is_average_of_costs(
         self,
         costs_1: Decimal,
         costs_2: Decimal,
-        expected_price: Decimal,
     ) -> None:
+        expected_price = (costs_1 + costs_2) / 2
         plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
@@ -82,14 +114,14 @@ class PriceCalculatorTests(BaseTestCase):
         self.cooperation_generator.create_cooperation(
             plans=[plan_1, plan_2],
         )
-        price = self.calculator.calculate_cooperative_price(plan_1)
-        assert price is not None
-        self.assertAlmostEqual(price, expected_price)
+        price1 = self.service.calculate_price(plan_1)
+        price2 = self.service.calculate_price(plan_2)
+        assert price1 == price2 == expected_price
 
     @parameterized.expand(
         [
-            (Decimal(10), Decimal(20), Decimal(30), Decimal(20)),
-            (Decimal(20), Decimal(30), Decimal(40), Decimal(30)),
+            (Decimal(10), Decimal(20), Decimal(30)),
+            (Decimal(20), Decimal(30), Decimal(40)),
         ]
     )
     def test_that_cooperative_price_for_three_companies_is_average_of_costs(
@@ -97,8 +129,8 @@ class PriceCalculatorTests(BaseTestCase):
         costs_1: Decimal,
         costs_2: Decimal,
         costs_3: Decimal,
-        expected_price: Decimal,
     ) -> None:
+        expected_price = (costs_1 + costs_2 + costs_3) / 3
         plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
@@ -114,15 +146,16 @@ class PriceCalculatorTests(BaseTestCase):
         self.cooperation_generator.create_cooperation(
             plans=[plan_1, plan_2, plan_3],
         )
-        price = self.calculator.calculate_cooperative_price(plan_1)
-        assert price is not None
-        self.assertAlmostEqual(price, expected_price)
+        price1 = self.service._calculate_cooperative_price(plan_1)
+        price2 = self.service._calculate_cooperative_price(plan_2)
+        price3 = self.service._calculate_cooperative_price(plan_3)
+        assert price1 == price2 == price3 == expected_price
 
     @parameterized.expand(
         [
-            (Decimal(1), 1, Decimal(3), 1, Decimal(2)),
-            (Decimal(1), 38, Decimal(3), 1, Decimal(2)),
-            (Decimal(1), 1, Decimal(3), 72, Decimal(2)),
+            (Decimal(1), 1, Decimal(3), 1),
+            (Decimal(1), 38, Decimal(3), 1),
+            (Decimal(1), 1, Decimal(3), 72),
         ]
     )
     def test_that_cooperative_price_for_two_companies_is_average_of_costs_independent_of_duration(
@@ -131,8 +164,8 @@ class PriceCalculatorTests(BaseTestCase):
         duration_1: int,
         costs_2: Decimal,
         duration_2: int,
-        expected_price: Decimal,
     ) -> None:
+        expected_price = (costs_1 + costs_2) / 2
         plan_1 = self.plan_generator.create_plan(
             costs=ProductionCosts(costs_1, Decimal(0), Decimal(0)),
             amount=1,
@@ -146,6 +179,6 @@ class PriceCalculatorTests(BaseTestCase):
         self.cooperation_generator.create_cooperation(
             plans=[plan_1, plan_2],
         )
-        price = self.calculator.calculate_cooperative_price(plan_1)
-        assert price is not None
-        self.assertAlmostEqual(price, expected_price)
+        price1 = self.service._calculate_cooperative_price(plan_1)
+        price2 = self.service._calculate_cooperative_price(plan_2)
+        assert price1 == price2 == expected_price

--- a/tests/www/presenters/data_generators.py
+++ b/tests/www/presenters/data_generators.py
@@ -164,7 +164,7 @@ class PlanDetailsGenerator:
             labour_cost=labour_cost,
             is_public_service=is_public_service,
             price_per_unit=price_per_unit,
-            labour_cost_per_unit=labour_cost_per_unit,
+            cost_per_unit=labour_cost_per_unit,
             is_cooperating=is_cooperating,
             cooperation=cooperation,
             creation_date=creation_date,

--- a/tests/www/presenters/test_company_consumptions_presenter.py
+++ b/tests/www/presenters/test_company_consumptions_presenter.py
@@ -32,7 +32,7 @@ class TestPresenter(BaseTestCase):
                     product_name="Produkt A",
                     product_description="Beschreibung für Produkt A.",
                     consumption_type=ConsumptionType.raw_materials,
-                    price_per_unit=Decimal("7.89"),
+                    paid_price_per_unit=Decimal("7.89"),
                     amount=321,
                 ),
                 ConsumptionQueryResponse(
@@ -41,7 +41,7 @@ class TestPresenter(BaseTestCase):
                     product_name="Produkt A",
                     product_description="Beschreibung für Produkt A.",
                     consumption_type=ConsumptionType.means_of_prod,
-                    price_per_unit=Decimal("100000"),
+                    paid_price_per_unit=Decimal("100000"),
                     amount=1,
                 ),
             ]

--- a/tests/www/presenters/test_private_consumptions_presenter.py
+++ b/tests/www/presenters/test_private_consumptions_presenter.py
@@ -38,9 +38,9 @@ class PresenterTests(BaseTestCase):
                     plan_id=uuid4(),
                     product_name="test product",
                     product_description="test product description",
-                    price_per_unit=Decimal("1"),
+                    paid_price_per_unit=Decimal("1"),
                     amount=1,
-                    price_total=Decimal("1"),
+                    paid_price_total=Decimal("1"),
                 )
             ]
         )


### PR DESCRIPTION
- New method "calculate_price" of PriceCalculator service
- Delete method "price_per_unit" from Plan record
- Unify variable names to either "price_per_unit" or "cost_per_unit"
- Delete redundant method of PriceChecker

Fixes issue #1295