### PR TITLE
Reduce code duplication in transfer display

### DIFF
--- a/arbeitszeit/anonymization.py
+++ b/arbeitszeit/anonymization.py
@@ -1,0 +1,52 @@
+"""
+Sentinels to represent anonymized values.
+"""
+
+from __future__ import annotations
+
+from typing import Final, TypeAlias
+from uuid import UUID
+
+
+class AnonymizedUUID:
+    """Marker class for anonymized UUIDs.
+
+    Prefer using the singleton instance ANONYMIZED_UUID instead of creating
+    new instances. Identity checks ("is") are the recommended way to detect
+    anonymized values.
+    """
+
+    __slots__: tuple[str, ...] = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "<ANONYMIZED_UUID>"
+
+    def __bool__(self) -> bool:  # pragma: no cover - defensive
+        raise TypeError("AnonymizedUUID cannot be used in a boolean context")
+
+
+class AnonymizedStr:
+    """Marker class for anonymized strings.
+
+    Prefer using the singleton instance ANONYMIZED_STR instead of creating
+    new instances. Identity checks ("is") are the recommended way to detect
+    anonymized values.
+    """
+
+    __slots__: tuple[str, ...] = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "<ANONYMIZED_STR>"
+
+    def __bool__(self) -> bool:  # pragma: no cover - defensive
+        raise TypeError("AnonymizedStr cannot be used in a boolean context")
+
+
+# Singleton sentinel instances (preferred values to use and compare against)
+ANONYMIZED_UUID: Final[AnonymizedUUID] = AnonymizedUUID()
+ANONYMIZED_STR: Final[AnonymizedStr] = AnonymizedStr()
+
+
+# Helpful type aliases
+MaybeAnonymizedUUID: TypeAlias = UUID | AnonymizedUUID
+MaybeAnonymizedStr: TypeAlias = str | AnonymizedStr

--- a/arbeitszeit/interactors/get_member_account.py
+++ b/arbeitszeit/interactors/get_member_account.py
@@ -1,67 +1,29 @@
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
 from arbeitszeit.repositories import DatabaseGateway
-from arbeitszeit.transfers import TransferType
-
-
-@dataclass
-class TransferInfo:
-    date: datetime
-    peer_name: str
-    transferred_value: Decimal
-    type: TransferType
-    is_debit_transfer: bool
+from arbeitszeit.services.account_details import AccountDetailsService, AccountTransfer
 
 
 @dataclass
 class GetMemberAccountResponse:
-    transfers: list[TransferInfo]
+    transfers: list[AccountTransfer]
     balance: Decimal
 
 
 @dataclass
 class GetMemberAccountInteractor:
     database_gateway: DatabaseGateway
+    account_details_service: AccountDetailsService
 
     def execute(self, member_id: UUID) -> GetMemberAccountResponse:
         member = self.database_gateway.get_members().with_id(member_id).first()
         assert member
-        transfers = self._get_account_transfers(member.account)
-        transfers.sort(key=lambda t: t.date, reverse=True)
+        account = member.account
+        transfers = self.account_details_service.get_account_transfers(account)
+        account_balance = self.account_details_service.get_account_balance(account)
         return GetMemberAccountResponse(
-            transfers=transfers, balance=self._get_account_balance(member.account)
+            transfers=sorted(transfers, key=lambda t: t.date, reverse=True),
+            balance=account_balance,
         )
-
-    def _get_account_transfers(self, account: UUID) -> list[TransferInfo]:
-        transfers: list[TransferInfo] = []
-        for transfer, debtor, creditor in (
-            self.database_gateway.get_transfers()
-            .where_account_is_debtor_or_creditor(account)
-            .joined_with_debtor_and_creditor()
-        ):
-            is_debit_transfer = transfer.debit_account == account
-            peer_name = creditor.get_name() if is_debit_transfer else debtor.get_name()
-            value = -transfer.value if is_debit_transfer else transfer.value
-            transfers.append(
-                TransferInfo(
-                    date=transfer.date,
-                    peer_name=peer_name,
-                    transferred_value=value,
-                    type=transfer.type,
-                    is_debit_transfer=is_debit_transfer,
-                )
-            )
-        return transfers
-
-    def _get_account_balance(self, account: UUID) -> Decimal:
-        result = (
-            self.database_gateway.get_accounts()
-            .with_id(account)
-            .joined_with_balance()
-            .first()
-        )
-        assert result
-        return result[1]

--- a/arbeitszeit/interactors/get_member_account.py
+++ b/arbeitszeit/interactors/get_member_account.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import List
 from uuid import UUID
 
 from arbeitszeit.repositories import DatabaseGateway
@@ -14,58 +13,55 @@ class TransferInfo:
     peer_name: str
     transferred_value: Decimal
     type: TransferType
+    is_debit_transfer: bool
 
 
 @dataclass
 class GetMemberAccountResponse:
-    transfers: List[TransferInfo]
+    transfers: list[TransferInfo]
     balance: Decimal
 
 
 @dataclass
 class GetMemberAccountInteractor:
-    database: DatabaseGateway
+    database_gateway: DatabaseGateway
 
     def execute(self, member_id: UUID) -> GetMemberAccountResponse:
-        member = self.database.get_members().with_id(member_id).first()
+        member = self.database_gateway.get_members().with_id(member_id).first()
         assert member
-        transfer_info: List[TransferInfo] = []
-        work_certificate_transfers = (
-            self.database.get_transfers()
-            .where_account_is_creditor(member.account)
-            .joined_with_debtor()
-        )
-        consumption_or_tax_transfers = (
-            self.database.get_transfers()
-            .where_account_is_debtor(member.account)
-            .joined_with_creditor()
-        )
-        for tf, debtor in work_certificate_transfers:
-            transfer_info.append(
-                TransferInfo(
-                    date=tf.date,
-                    peer_name=debtor.get_name(),
-                    transferred_value=tf.value,
-                    type=TransferType.work_certificates,
-                )
-            )
-        for tf, creditor in consumption_or_tax_transfers:
-            transfer_info.append(
-                TransferInfo(
-                    date=tf.date,
-                    peer_name=creditor.get_name(),
-                    transferred_value=-tf.value,  # negative value for consumption or tax
-                    type=tf.type,
-                )
-            )
-        transfer_info.sort(key=lambda t: t.date, reverse=True)
+        transfers = self._get_account_transfers(member.account)
+        transfers.sort(key=lambda t: t.date, reverse=True)
         return GetMemberAccountResponse(
-            transfers=transfer_info, balance=self.get_account_balance(member.account)
+            transfers=transfers, balance=self._get_account_balance(member.account)
         )
 
-    def get_account_balance(self, account: UUID) -> Decimal:
+    def _get_account_transfers(self, account: UUID) -> list[TransferInfo]:
+        transfers: list[TransferInfo] = []
+        for transfer, debtor, creditor in (
+            self.database_gateway.get_transfers()
+            .where_account_is_debtor_or_creditor(account)
+            .joined_with_debtor_and_creditor()
+        ):
+            is_debit_transfer = transfer.debit_account == account
+            peer_name = creditor.get_name() if is_debit_transfer else debtor.get_name()
+            value = -transfer.value if is_debit_transfer else transfer.value
+            transfers.append(
+                TransferInfo(
+                    date=transfer.date,
+                    peer_name=peer_name,
+                    transferred_value=value,
+                    type=transfer.type,
+                    is_debit_transfer=is_debit_transfer,
+                )
+            )
+        return transfers
+
+    def _get_account_balance(self, account: UUID) -> Decimal:
         result = (
-            self.database.get_accounts().with_id(account).joined_with_balance().first()
+            self.database_gateway.get_accounts()
+            .with_id(account)
+            .joined_with_balance()
+            .first()
         )
         assert result
         return result[1]

--- a/arbeitszeit/interactors/show_prd_account_details.py
+++ b/arbeitszeit/interactors/show_prd_account_details.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
-from itertools import accumulate
 from uuid import UUID
 
-from arbeitszeit.records import AccountOwner, Cooperation, Member
 from arbeitszeit.repositories import DatabaseGateway
-from arbeitszeit.transfers import TransferType
+from arbeitszeit.services.account_details import (
+    AccountDetailsService,
+    AccountTransfer,
+    PlotDetails,
+    construct_plot_data,
+)
 
 
 @dataclass
@@ -14,39 +16,10 @@ class Request:
     company_id: UUID
 
 
-class MemberPeer: ...
-
-
-@dataclass
-class CompanyPeer:
-    name: str
-    id: UUID
-
-
-@dataclass
-class CooperationPeer:
-    name: str
-    id: UUID
-
-
-@dataclass
-class TransferInfo:
-    type: TransferType
-    date: datetime
-    volume: Decimal
-    peer: MemberPeer | CompanyPeer | CooperationPeer | None
-
-
-@dataclass
-class PlotDetails:
-    timestamps: list[datetime]
-    accumulated_volumes: list[Decimal]
-
-
 @dataclass
 class Response:
     company_id: UUID
-    transfers: list[TransferInfo]
+    transfers: list[AccountTransfer]
     account_balance: Decimal
     plot: PlotDetails
 
@@ -54,95 +27,19 @@ class Response:
 @dataclass
 class ShowPRDAccountDetailsInteractor:
     database_gateway: DatabaseGateway
+    account_details_service: AccountDetailsService
 
     def show_details(self, request: Request) -> Response:
         company = (
             self.database_gateway.get_companies().with_id(request.company_id).first()
         )
         assert company
-        transfers = self._get_account_transfers(company.product_account)
-        transfers.sort(key=lambda t: t.date)
-        transfers_descending = transfers.copy()
-        transfers_descending.reverse()
-        account_balance = self._get_account_balance(company.product_account)
-        plot = PlotDetails(
-            timestamps=self._get_plot_dates_in_ascending_order(transfers),
-            accumulated_volumes=self._get_accumulated_plot_volumes_in_ascending_order(
-                transfers
-            ),
-        )
+        account = company.product_account
+        transfers = self.account_details_service.get_account_transfers(account)
+        account_balance = self.account_details_service.get_account_balance(account)
         return Response(
             company_id=request.company_id,
-            transfers=transfers_descending,
+            transfers=sorted(transfers, key=lambda t: t.date, reverse=True),
             account_balance=account_balance,
-            plot=plot,
-        )
-
-    def _get_account_transfers(self, account: UUID) -> list[TransferInfo]:
-        transfers: list[TransferInfo] = []
-        for transfer, debtor, creditor in (
-            self.database_gateway.get_transfers()
-            .where_account_is_debtor_or_creditor(account)
-            .joined_with_debtor_and_creditor()
-        ):
-            is_debit_transfer = transfer.debit_account == account
-            transfers.append(
-                TransferInfo(
-                    type=transfer.type,
-                    date=transfer.date,
-                    volume=-transfer.value if is_debit_transfer else transfer.value,
-                    peer=self._create_peer_info(
-                        debtor, creditor, is_debit_transfer, transfer.type
-                    ),
-                )
-            )
-        return transfers
-
-    def _get_account_balance(self, account: UUID) -> Decimal:
-        result = (
-            self.database_gateway.get_accounts()
-            .with_id(account)
-            .joined_with_balance()
-            .first()
-        )
-        assert result
-        return result[1]
-
-    def _get_plot_dates_in_ascending_order(
-        self, transfers: list[TransferInfo]
-    ) -> list[datetime]:
-        timestamps = [t.date for t in transfers]
-        return timestamps
-
-    def _get_accumulated_plot_volumes_in_ascending_order(
-        self, transfers: list[TransferInfo]
-    ) -> list[Decimal]:
-        volumes_cumsum = list(accumulate(t.volume for t in transfers))
-        return volumes_cumsum
-
-    def _create_peer_info(
-        self,
-        debtor: AccountOwner,
-        creditor: AccountOwner,
-        is_debit_transfer: bool,
-        transfer_type: TransferType,
-    ) -> MemberPeer | CompanyPeer | CooperationPeer | None:
-        if transfer_type in [
-            TransferType.credit_p,
-            TransferType.credit_r,
-            TransferType.credit_a,
-        ]:
-            #  Transfer comes from one of company's own accounts
-            return None
-        peer = creditor if is_debit_transfer else debtor
-        if isinstance(peer, Member):
-            return MemberPeer()
-        elif isinstance(peer, Cooperation):
-            return CooperationPeer(
-                id=peer.id,
-                name=peer.get_name(),
-            )
-        return CompanyPeer(
-            id=peer.id,
-            name=peer.get_name(),
+            plot=construct_plot_data(transfers),
         )

--- a/arbeitszeit/services/account_details.py
+++ b/arbeitszeit/services/account_details.py
@@ -43,6 +43,7 @@ class AccountTransfer:
     volume: Decimal
     is_debit_transfer: bool
     transfer_party: TransferParty
+    debtor_equals_creditor: bool
 
 
 @dataclass
@@ -75,6 +76,7 @@ class AccountDetailsService:
                     volume=-transfer.value if is_debit_transfer else transfer.value,
                     is_debit_transfer=is_debit_transfer,
                     transfer_party=transfer_party,
+                    debtor_equals_creditor=debtor.id == creditor.id,
                 )
             )
         return transfers

--- a/arbeitszeit_flask/templates/macros/transfers.html
+++ b/arbeitszeit_flask/templates/macros/transfers.html
@@ -1,5 +1,4 @@
-<!--Used in company's p, r, a accounts-->
-{% macro basic_transfer(date, type, volume, is_debit_transfer) %}
+{% macro transfer_with_party(date, type, volume, is_debit_transfer, party_icon, party_name) %}
 <article class="media">
     <div class="media-left">
         <p class="pt-1">
@@ -12,6 +11,10 @@
                 <strong class="is-size-5">
                     {{ type }}
                 </strong>
+                {% if party_name %}
+                <br>
+                <span class="icon">{{ party_icon|icon }}</span>&nbsp;<span>{{ party_name }}</span>
+                {% endif %}
             </p>
         </div>
     </div>

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -40,7 +40,7 @@
                     </div>
                 </div>
                 <div class="media-right">
-                    <p class="is-size-5 pt-1 {{ 'has-text-success' if transfer.is_volume_positive else 'has-text-danger' }}">
+                    <p class="is-size-5 pt-1 {{ 'has-text-danger' if transfer.is_debit_transfer else 'has-text-success' }}">
                         {{ transfer.volume }}
                     </p>
                 </div>

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -32,16 +32,14 @@
                     <div class="content">
                         <p>
                             <strong class="is-size-5">
-                                {{ transfer.type }}
+                                {{ transfer.transfer_type }}
                             </strong>
-                            <br>
-                            <small>{{ transfer.user_name }}</small>
                         </p>
                     </div>
                 </div>
                 <div class="media-right">
                     <p class="is-size-5 pt-1 {{ 'has-text-danger' if transfer.is_debit_transfer else 'has-text-success' }}">
-                        {{ transfer.volume }}
+                        {{ transfer.transfer_volume }}
                     </p>
                 </div>
             </article>

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+{% from 'macros/transfers.html' import transfer_with_party %}
 <div class="section has-text-centered">
     <h1 class="title">
         {{ gettext("My Account") }}
@@ -22,27 +23,7 @@
         <div class="column is-half">
             {% if view_model.transfers is defined and view_model.transfers|length %}
             {% for transfer in view_model.transfers %}
-            <article class="media">
-                <div class="media-left">
-                    <p class="pt-1">
-                        <small class="has-text-weight-semibold">{{ transfer.date }}</small><br>
-                    </p>
-                </div>
-                <div class="media-content">
-                    <div class="content">
-                        <p>
-                            <strong class="is-size-5">
-                                {{ transfer.transfer_type }}
-                            </strong>
-                        </p>
-                    </div>
-                </div>
-                <div class="media-right">
-                    <p class="is-size-5 pt-1 {{ 'has-text-danger' if transfer.is_debit_transfer else 'has-text-success' }}">
-                        {{ transfer.transfer_volume }}
-                    </p>
-                </div>
-            </article>
+                {{ transfer_with_party(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer, transfer.party_icon, transfer.party_name) }}
             {% endfor %}
             {% endif %}
         </div>

--- a/arbeitszeit_flask/templates/user/company_account_a.html
+++ b/arbeitszeit_flask/templates/user/company_account_a.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-{% from 'macros/transfers.html' import basic_transfer %}
+{% from 'macros/transfers.html' import transfer_with_party %}
 
 <section class="section columns has-text-centered">
     <div class="column"></div>
@@ -31,7 +31,7 @@
         <div class="section has-text-left">
             {% if view_model.transfers is defined and view_model.transfers|length %}
             {% for transfer in view_model.transfers %}
-            {{ basic_transfer(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer) }}
+                {{ transfer_with_party(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer, transfer.party_icon, transfer.party_name) }}
             {% endfor %}
             {% endif %}
         </div>

--- a/arbeitszeit_flask/templates/user/company_account_p.html
+++ b/arbeitszeit_flask/templates/user/company_account_p.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-{% from 'macros/transfers.html' import basic_transfer %}
+{% from 'macros/transfers.html' import transfer_with_party %}
 
 <section class="section has-text-centered columns">
     <div class="column"></div>
@@ -32,7 +32,7 @@
         <div class="section has-text-left">
             {% if view_model.transfers is defined and view_model.transfers|length %}
             {% for transfer in view_model.transfers %}
-            {{ basic_transfer(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer) }}
+                {{ transfer_with_party(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer, transfer.party_icon, transfer.party_name) }}
             {% endfor %}
             {% endif %}
         </div>

--- a/arbeitszeit_flask/templates/user/company_account_prd.html
+++ b/arbeitszeit_flask/templates/user/company_account_prd.html
@@ -40,7 +40,7 @@
                         <p>
                             <strong class="is-size-5">
                                 {{ transfer.transfer_type }}
-                            </strong><span class="icon">{{ transfer.peer_type_icon|icon }}</span>&nbsp;<span>{{ transfer.peer_name }}</span>
+                            </strong><span class="icon">{{ transfer.party_icon|icon }}</span>&nbsp;<span>{{ transfer.party_name }}</span>
                         </p>
                     </div>
                 </div>

--- a/arbeitszeit_flask/templates/user/company_account_prd.html
+++ b/arbeitszeit_flask/templates/user/company_account_prd.html
@@ -45,7 +45,7 @@
                     </div>
                 </div>
                 <div class="media-right">
-                    <p class="is-size-5 pt-1 {{ 'has-text-success' if transfer.transfer_volume|float >= 0 else 'has-text-danger' }}">
+                    <p class="is-size-5 pt-1 {{ 'has-text-danger' if transfer.is_debit_transfer else 'has-text-success' }}">
                         {{ transfer.transfer_volume }}
                     </p>
                 </div>

--- a/arbeitszeit_flask/templates/user/company_account_prd.html
+++ b/arbeitszeit_flask/templates/user/company_account_prd.html
@@ -1,11 +1,13 @@
 {% extends "base.html" %}
 
+
 {% block navbar_start %}
 {% from 'macros/navbar.html' import navbar %}
 {{ navbar(view_model.navbar_items) }}
 {% endblock %}
 
 {% block content %}
+{% from 'macros/transfers.html' import transfer_with_party %}
 <section class="section columns has-text-centered">
     <div class="column"></div>
     <div class="column is-two-thirds">
@@ -29,27 +31,7 @@
         <div class="section has-text-left">
             {% if view_model.show_transfers %}
             {% for transfer in view_model.transfers %}
-            <article class="media">
-                <div class="media-left">
-                    <p class="pt-1">
-                        <small class="has-text-weight-semibold">{{ transfer.date }}</small><br>
-                    </p>
-                </div>
-                <div class="media-content">
-                    <div class="content">
-                        <p>
-                            <strong class="is-size-5">
-                                {{ transfer.transfer_type }}
-                            </strong><span class="icon">{{ transfer.party_icon|icon }}</span>&nbsp;<span>{{ transfer.party_name }}</span>
-                        </p>
-                    </div>
-                </div>
-                <div class="media-right">
-                    <p class="is-size-5 pt-1 {{ 'has-text-danger' if transfer.is_debit_transfer else 'has-text-success' }}">
-                        {{ transfer.transfer_volume }}
-                    </p>
-                </div>
-            </article>
+                {{ transfer_with_party(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer, transfer.party_icon, transfer.party_name) }}
             {% endfor %}
             {% endif %}
         </div>

--- a/arbeitszeit_flask/templates/user/company_account_r.html
+++ b/arbeitszeit_flask/templates/user/company_account_r.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-{% from 'macros/transfers.html' import basic_transfer %}
+{% from 'macros/transfers.html' import transfer_with_party %}
 
 <section class="section has-text-centered columns">
     <div class="column"></div>
@@ -31,7 +31,7 @@
         <div class="section has-text-left">
             {% if view_model.transfers is defined and view_model.transfers|length %}
             {% for transfer in view_model.transfers %}
-            {{ basic_transfer(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer) }}
+                {{ transfer_with_party(transfer.date, transfer.transfer_type, transfer.transfer_volume, transfer.is_debit_transfer, transfer.party_icon, transfer.party_name) }}
             {% endfor %}
             {% endif %}
         </div>

--- a/arbeitszeit_web/www/presenters/get_member_account_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_member_account_presenter.py
@@ -17,7 +17,7 @@ class GetMemberAccountPresenter:
         type: str
         user_name: str
         volume: str
-        is_volume_positive: bool
+        is_debit_transfer: bool
 
     @dataclass
     class ViewModel:
@@ -39,7 +39,7 @@ class GetMemberAccountPresenter:
                 type=self._transfer_type_as_string(t.type),
                 user_name=t.peer_name,
                 volume=f"{round(t.transferred_value, 2)}",
-                is_volume_positive=t.transferred_value >= 0,
+                is_debit_transfer=t.is_debit_transfer,
             )
             for t in interactor_response.transfers
         ]

--- a/arbeitszeit_web/www/presenters/get_member_account_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_member_account_presenter.py
@@ -1,58 +1,31 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import List
 
 from arbeitszeit.interactors.get_member_account import GetMemberAccountResponse
-from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.www.presenters.transfers import TransferInfo, TransferPresenter
 
 
 @dataclass
 class GetMemberAccountPresenter:
     @dataclass
-    class Transfer:
-        date: str
-        type: str
-        user_name: str
-        volume: str
-        is_debit_transfer: bool
-
-    @dataclass
     class ViewModel:
         balance: str
         is_balance_positive: bool
-        transfers: List[GetMemberAccountPresenter.Transfer]
+        transfers: list[TransferInfo]
 
     datetime_formatter: DatetimeFormatter
     translator: Translator
+    transfer_presenter: TransferPresenter
 
     def present_member_account(
         self, interactor_response: GetMemberAccountResponse
     ) -> ViewModel:
-        transfers = [
-            self.Transfer(
-                date=self.datetime_formatter.format_datetime(
-                    t.date, fmt="%d.%m.%Y %H:%M"
-                ),
-                type=self._transfer_type_as_string(t.type),
-                user_name=t.peer_name,
-                volume=f"{round(t.transferred_value, 2)}",
-                is_debit_transfer=t.is_debit_transfer,
-            )
-            for t in interactor_response.transfers
-        ]
+        transfers = self.transfer_presenter.present_transfers(
+            interactor_response.transfers
+        )
         return self.ViewModel(
             balance=f"{round(interactor_response.balance, 2)}",
             is_balance_positive=interactor_response.balance >= 0,
             transfers=transfers,
         )
-
-    def _transfer_type_as_string(self, t: TransferType) -> str:
-        if t == TransferType.work_certificates:
-            return self.translator.gettext("Work certificates")
-        elif t == TransferType.taxes:
-            return self.translator.gettext("Contribution to public sector")
-        else:
-            return self.translator.gettext("Consumption")

--- a/arbeitszeit_web/www/presenters/list_transfers_presenter.py
+++ b/arbeitszeit_web/www/presenters/list_transfers_presenter.py
@@ -11,7 +11,7 @@ from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.presenters.transfers import (
-    transfer_description_from_transfer_type,
+    description_from_transfer_type,
 )
 
 
@@ -61,7 +61,7 @@ class ListTransfersPresenter:
         rows = [
             ResultTableRow(
                 date=self._format_date(transfer.date),
-                transfer_type=transfer_description_from_transfer_type(
+                transfer_type=description_from_transfer_type(
                     self.translator, transfer.transfer_type
                 ),
                 debit_account=(

--- a/arbeitszeit_web/www/presenters/list_transfers_presenter.py
+++ b/arbeitszeit_web/www/presenters/list_transfers_presenter.py
@@ -5,12 +5,14 @@ from uuid import UUID
 
 from arbeitszeit.interactors.list_transfers import AccountOwnerType
 from arbeitszeit.interactors.list_transfers import Response as InteractorResponse
-from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.pagination import Pagination, Paginator
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
+from arbeitszeit_web.www.presenters.transfers import (
+    transfer_description_from_transfer_type,
+)
 
 
 @dataclass
@@ -59,7 +61,9 @@ class ListTransfersPresenter:
         rows = [
             ResultTableRow(
                 date=self._format_date(transfer.date),
-                transfer_type=self._transform_transfer_type(transfer.transfer_type),
+                transfer_type=transfer_description_from_transfer_type(
+                    self.translator, transfer.transfer_type
+                ),
                 debit_account=(
                     str(transfer.debit_account) if transfer.debit_account else ""
                 ),
@@ -100,49 +104,6 @@ class ListTransfersPresenter:
             date,
             fmt="%d.%m.%Y %H:%M",
         )
-
-    def _transform_transfer_type(self, transfer_type: TransferType) -> str:
-        match transfer_type.name:
-            case "credit_p":
-                return self.translator.gettext("Credit for fixed means of production")
-            case "credit_r":
-                return self.translator.gettext("Credit for liquid means of production")
-            case "credit_a":
-                return self.translator.gettext("Credit for labour")
-            case "credit_public_p":
-                return self.translator.gettext(
-                    "Credit for fixed means of production (public service)"
-                )
-            case "credit_public_r":
-                return self.translator.gettext(
-                    "Credit for liquid means of production (public service)"
-                )
-            case "credit_public_a":
-                return self.translator.gettext("Credit for labour (public service)")
-            case "private_consumption":
-                return self.translator.gettext("Private consumption")
-            case "productive_consumption_p":
-                return self.translator.gettext(
-                    "Productive consumption of fixed means of production"
-                )
-            case "productive_consumption_r":
-                return self.translator.gettext(
-                    "Productive consumption of liquid means of production"
-                )
-            case "compensation_for_coop":
-                return self.translator.gettext(
-                    "Compensation for overproductive planning"
-                )
-            case "compensation_for_company":
-                return self.translator.gettext(
-                    "Compensation for underproductive planning"
-                )
-            case "work_certificates":
-                return self.translator.gettext("Work certificates")
-            case "taxes":
-                return self.translator.gettext("Contribution to public sector")
-            case _:
-                raise ValueError(f"Unknown transfer type: {transfer_type}")
 
     def _convert_account_owner_name(
         self, name: str | None, owner_type: AccountOwnerType

--- a/arbeitszeit_web/www/presenters/show_a_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_a_account_details_presenter.py
@@ -1,29 +1,19 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import List
 
 from arbeitszeit.interactors import show_a_account_details
-from arbeitszeit.services.account_details import AccountTransfer
-from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
+from arbeitszeit_web.www.presenters.transfers import TransferInfo, TransferPresenter
 
 
 @dataclass
 class ShowAAccountDetailsPresenter:
     @dataclass
-    class TransferInfo:
-        transfer_type: str
-        date: str
-        transfer_volume: str
-        is_debit_transfer: bool
-
-    @dataclass
     class ViewModel:
-        transfers: List[ShowAAccountDetailsPresenter.TransferInfo]
+        transfers: List[TransferInfo]
         account_balance: str
         plot_url: str
         navbar_items: list[NavbarItem]
@@ -31,13 +21,14 @@ class ShowAAccountDetailsPresenter:
     translator: Translator
     url_index: UrlIndex
     datetime_formatter: DatetimeFormatter
+    transfer_presenter: TransferPresenter
 
     def present(
         self, interactor_response: show_a_account_details.Response
     ) -> ViewModel:
-        transfers = [
-            self._create_info(transfer) for transfer in interactor_response.transfers
-        ]
+        transfers = self.transfer_presenter.present_transfers(
+            interactor_response.transfers
+        )
         return self.ViewModel(
             transfers=transfers,
             account_balance=str(round(interactor_response.account_balance, 2)),
@@ -54,22 +45,3 @@ class ShowAAccountDetailsPresenter:
                 NavbarItem(text=self.translator.gettext("Account a"), url=None),
             ],
         )
-
-    def _create_info(self, transfer: AccountTransfer) -> TransferInfo:
-        return self.TransferInfo(
-            transfer_type=self._get_transfer_type(transfer.type),
-            date=self.datetime_formatter.format_datetime(
-                date=transfer.date, fmt="%d.%m.%Y %H:%M"
-            ),
-            transfer_volume=str(round(transfer.volume, 2)),
-            is_debit_transfer=transfer.is_debit_transfer,
-        )
-
-    def _get_transfer_type(self, transfer_type: TransferType) -> str:
-        if (
-            transfer_type == TransferType.credit_a
-            or transfer_type == TransferType.credit_public_a
-        ):
-            return self.translator.gettext("Credit")
-        else:
-            return self.translator.gettext("Payment")

--- a/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
@@ -1,29 +1,22 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import List
 
 from arbeitszeit.interactors.show_p_account_details import ShowPAccountDetailsInteractor
-from arbeitszeit.services.account_details import AccountTransfer
-from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
+from arbeitszeit_web.www.presenters.transfers import (
+    TransferInfo,
+    TransferPresenter,
+)
 
 
 @dataclass
 class ShowPAccountDetailsPresenter:
     @dataclass
-    class TransferInfo:
-        transfer_type: str
-        date: str
-        transfer_volume: str
-        is_debit_transfer: bool
-
-    @dataclass
     class ViewModel:
-        transfers: List[ShowPAccountDetailsPresenter.TransferInfo]
+        transfers: List[TransferInfo]
         account_balance: str
         plot_url: str
         navbar_items: list[NavbarItem]
@@ -31,13 +24,14 @@ class ShowPAccountDetailsPresenter:
     translator: Translator
     url_index: UrlIndex
     datetime_formatter: DatetimeFormatter
+    transfer_presenter: TransferPresenter
 
     def present(
         self, interactor_response: ShowPAccountDetailsInteractor.Response
     ) -> ViewModel:
-        transfers = [
-            self._create_info(transfer) for transfer in interactor_response.transfers
-        ]
+        transfers = self.transfer_presenter.present_transfers(
+            interactor_response.transfers
+        )
         return self.ViewModel(
             transfers=transfers,
             account_balance=str(round(interactor_response.account_balance, 2)),
@@ -53,19 +47,4 @@ class ShowPAccountDetailsPresenter:
                 ),
                 NavbarItem(text=self.translator.gettext("Account p"), url=None),
             ],
-        )
-
-    def _create_info(self, transfer: AccountTransfer) -> TransferInfo:
-        transfer_type = (
-            self.translator.gettext("Consumption")
-            if transfer.type == TransferType.productive_consumption_p
-            else self.translator.gettext("Credit")
-        )
-        return self.TransferInfo(
-            transfer_type=transfer_type,
-            date=self.datetime_formatter.format_datetime(
-                date=transfer.date, fmt="%d.%m.%Y %H:%M"
-            ),
-            transfer_volume=str(round(transfer.volume, 2)),
-            is_debit_transfer=transfer.is_debit_transfer,
         )

--- a/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
@@ -23,8 +23,8 @@ class ShowPRDAccountDetailsPresenter:
         date: str
         transfer_volume: str
         is_debit_transfer: bool
-        peer_name: str
-        peer_type_icon: str
+        party_name: str
+        party_icon: str
 
     @dataclass
     class ViewModel:
@@ -73,10 +73,10 @@ class ShowPRDAccountDetailsPresenter:
             ),
             transfer_volume=str(round(transfer.volume, 2)),
             is_debit_transfer=transfer.is_debit_transfer,
-            peer_name=self._get_transfer_party_name(
+            party_name=self._get_transfer_party_name(
                 transfer.transfer_party, transfer.debtor_equals_creditor
             ),
-            peer_type_icon=self._get_transfer_party_type_icon(
+            party_icon=self._get_transfer_party_type_icon(
                 transfer.transfer_party, transfer.debtor_equals_creditor
             ),
         )

--- a/arbeitszeit_web/www/presenters/show_r_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_r_account_details_presenter.py
@@ -1,29 +1,18 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import List
 
 from arbeitszeit.interactors import show_r_account_details
-from arbeitszeit.services import account_details
-from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
+from arbeitszeit_web.www.presenters.transfers import TransferInfo, TransferPresenter
 
 
 @dataclass
 class ShowRAccountDetailsPresenter:
     @dataclass
-    class TransferInfo:
-        transfer_type: str
-        date: str
-        transfer_volume: str
-        is_debit_transfer: bool
-
-    @dataclass
     class ViewModel:
-        transfers: List[ShowRAccountDetailsPresenter.TransferInfo]
+        transfers: list[TransferInfo]
         account_balance: str
         plot_url: str
         navbar_items: list[NavbarItem]
@@ -31,13 +20,14 @@ class ShowRAccountDetailsPresenter:
     translator: Translator
     url_index: UrlIndex
     datetime_formatter: DatetimeFormatter
+    transfer_presenter: TransferPresenter
 
     def present(
         self, interactor_response: show_r_account_details.Response
     ) -> ViewModel:
-        transfers = [
-            self._create_info(transfer) for transfer in interactor_response.transfers
-        ]
+        transfers = self.transfer_presenter.present_transfers(
+            interactor_response.transfers
+        )
         return self.ViewModel(
             transfers=transfers,
             account_balance=str(round(interactor_response.account_balance, 2)),
@@ -53,19 +43,4 @@ class ShowRAccountDetailsPresenter:
                 ),
                 NavbarItem(text=self.translator.gettext("Account r"), url=None),
             ],
-        )
-
-    def _create_info(self, transfer: account_details.AccountTransfer) -> TransferInfo:
-        transfer_type = (
-            self.translator.gettext("Consumption")
-            if transfer.type == TransferType.productive_consumption_r
-            else self.translator.gettext("Credit")
-        )
-        return self.TransferInfo(
-            transfer_type=transfer_type,
-            date=self.datetime_formatter.format_datetime(
-                date=transfer.date, fmt="%d.%m.%Y %H:%M"
-            ),
-            transfer_volume=str(round(transfer.volume, 2)),
-            is_debit_transfer=transfer.is_debit_transfer,
         )

--- a/arbeitszeit_web/www/presenters/transfers.py
+++ b/arbeitszeit_web/www/presenters/transfers.py
@@ -77,21 +77,21 @@ def description_from_transfer_type(
 ) -> str:
     match transfer_type.name:
         case "credit_p":
-            return translator.gettext("Credit for fixed means of production")
+            return translator.gettext("Planned fixed means of production")
         case "credit_r":
-            return translator.gettext("Credit for liquid means of production")
+            return translator.gettext("Planned liquid means of production")
         case "credit_a":
-            return translator.gettext("Credit for labour")
+            return translator.gettext("Planned labour")
         case "credit_public_p":
             return translator.gettext(
-                "Credit for fixed means of production (public service)"
+                "Planned fixed means of production (public service)"
             )
         case "credit_public_r":
             return translator.gettext(
-                "Credit for liquid means of production (public service)"
+                "Planned liquid means of production (public service)"
             )
         case "credit_public_a":
-            return translator.gettext("Credit for labour (public service)")
+            return translator.gettext("Planned labour (public service)")
         case "private_consumption":
             return translator.gettext("Private consumption")
         case "productive_consumption_p":

--- a/arbeitszeit_web/www/presenters/transfers.py
+++ b/arbeitszeit_web/www/presenters/transfers.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+
+from arbeitszeit.services.account_details import AccountTransfer
+from arbeitszeit.transfers import TransferType
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class TransferInfo:
+    transfer_type: str
+    date: str
+    transfer_volume: str
+    is_debit_transfer: bool
+
+
+@dataclass
+class TransferPresenter:
+    translator: Translator
+    datetime_formatter: DatetimeFormatter
+
+    def present_transfers(self, transfers: list[AccountTransfer]) -> list[TransferInfo]:
+        return [self._create_info(transfer) for transfer in transfers]
+
+    def _create_info(self, transfer: AccountTransfer) -> TransferInfo:
+        return TransferInfo(
+            transfer_type=transfer_description_from_transfer_type(
+                self.translator, transfer.type
+            ),
+            date=self.datetime_formatter.format_datetime(
+                date=transfer.date, fmt="%d.%m.%Y %H:%M"
+            ),
+            transfer_volume=str(round(transfer.volume, 2)),
+            is_debit_transfer=transfer.is_debit_transfer,
+        )
+
+
+def transfer_description_from_transfer_type(
+    translator: Translator, transfer_type: TransferType
+) -> str:
+    match transfer_type.name:
+        case "credit_p":
+            return translator.gettext("Credit for fixed means of production")
+        case "credit_r":
+            return translator.gettext("Credit for liquid means of production")
+        case "credit_a":
+            return translator.gettext("Credit for labour")
+        case "credit_public_p":
+            return translator.gettext(
+                "Credit for fixed means of production (public service)"
+            )
+        case "credit_public_r":
+            return translator.gettext(
+                "Credit for liquid means of production (public service)"
+            )
+        case "credit_public_a":
+            return translator.gettext("Credit for labour (public service)")
+        case "private_consumption":
+            return translator.gettext("Private consumption")
+        case "productive_consumption_p":
+            return translator.gettext(
+                "Productive consumption of fixed means of production"
+            )
+        case "productive_consumption_r":
+            return translator.gettext(
+                "Productive consumption of liquid means of production"
+            )
+        case "compensation_for_coop":
+            return translator.gettext("Compensation for overproductive planning")
+        case "compensation_for_company":
+            return translator.gettext("Compensation for underproductive planning")
+        case "work_certificates":
+            return translator.gettext("Work certificates")
+        case "taxes":
+            return translator.gettext("Contribution to public sector")
+        case _:
+            raise ValueError(f"Unknown transfer type: {transfer_type}")

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -431,6 +431,7 @@ class ConsumptionGenerator:
 class TransferGenerator:
     datetime_service: FakeDatetimeService
     database_gateway: DatabaseGateway
+    company_generator: CompanyGenerator
 
     def create_transfer(
         self,
@@ -443,9 +444,11 @@ class TransferGenerator:
         if date is None:
             date = self.datetime_service.now()
         if debit_account is None:
-            debit_account = self.database_gateway.create_account().id
+            company = self.company_generator.create_company_record()
+            debit_account = company.means_account
         if credit_account is None:
-            credit_account = self.database_gateway.create_account().id
+            company = self.company_generator.create_company_record()
+            credit_account = company.product_account
         if value is None:
             value = Decimal(10)
         if type is None:

--- a/tests/interactors/test_get_member_account.py
+++ b/tests/interactors/test_get_member_account.py
@@ -55,8 +55,8 @@ class GetMemberAccountTests(BaseTestCase):
         )
         response = self.interactor.execute(member)
         assert len(response.transfers) == 1
-        assert response.transfers[0].peer_name == expected_company_name
-        assert response.transfers[0].transferred_value == Decimal(-10)
+        assert response.transfers[0].transfer_party.name == expected_company_name
+        assert response.transfers[0].volume == Decimal(-10)
         assert response.transfers[0].type == TransferType.private_consumption
         assert response.balance == Decimal(-10)
 
@@ -77,8 +77,8 @@ class GetMemberAccountTests(BaseTestCase):
             consumer=member, amount=1, plan=plan
         )
         response = self.interactor.execute(member)
-        assert response.transfers[0].transferred_value == Decimal("0")
-        assert str(response.transfers[0].transferred_value) == "0"
+        assert response.transfers[0].volume == Decimal("0")
+        assert str(response.transfers[0].volume) == "0"
 
     def test_that_after_member_has_worked_info_on_certificates_and_taxes_are_generated(
         self,
@@ -123,9 +123,9 @@ class GetMemberAccountTests(BaseTestCase):
         )
         response = self.interactor.execute(member)
         transfer = response.transfers[0]
-        assert transfer.peer_name == self.social_accounting_name
+        assert transfer.transfer_party.name == self.social_accounting_name
         assert transfer.type == TransferType.taxes
-        assert transfer.transferred_value == Decimal("0")
+        assert transfer.volume == Decimal("0")
 
     def test_that_correct_work_certificates_info_is_generated(self) -> None:
         expected_company_name = "test company name"
@@ -140,8 +140,8 @@ class GetMemberAccountTests(BaseTestCase):
         )
         response = self.interactor.execute(member)
         transfer = response.transfers[1]
-        assert transfer.peer_name == expected_company_name
-        assert transfer.transferred_value == Decimal(8.5)
+        assert transfer.transfer_party.name == expected_company_name
+        assert transfer.volume == Decimal(8.5)
         assert transfer.type == TransferType.work_certificates
 
     def test_that_correct_peer_name_info_is_generated_in_correct_order_after_several_transfers_of_different_kind(
@@ -185,19 +185,19 @@ class GetMemberAccountTests(BaseTestCase):
         assert len(response.transfers) == 5  # 1 consumption, 2 work certificates, 2 tax
 
         trans1 = response.transfers.pop()
-        assert trans1.peer_name == company1_name
+        assert trans1.transfer_party.name == company1_name
 
         trans2 = response.transfers.pop()
-        assert trans2.peer_name == self.social_accounting_name
+        assert trans2.transfer_party.name == self.social_accounting_name
 
         trans3 = response.transfers.pop()
-        assert trans3.peer_name == company1_name
+        assert trans3.transfer_party.name == company1_name
 
         trans4 = response.transfers.pop()
-        assert trans4.peer_name == company2_name
+        assert trans4.transfer_party.name == company2_name
 
         trans5 = response.transfers.pop()
-        assert trans5.peer_name == self.social_accounting_name
+        assert trans5.transfer_party.name == self.social_accounting_name
 
     @parameterized.expand([(True,), (False,)])
     def test_that_transfer_is_set_as_debit_transfer_if_that_is_the_case(

--- a/tests/interactors/test_get_member_account.py
+++ b/tests/interactors/test_get_member_account.py
@@ -144,7 +144,7 @@ class GetMemberAccountTests(BaseTestCase):
         assert transfer.volume == Decimal(8.5)
         assert transfer.type == TransferType.work_certificates
 
-    def test_that_correct_peer_name_info_is_generated_in_correct_order_after_several_transfers_of_different_kind(
+    def test_that_correct_party_name_info_is_generated_in_correct_order_after_several_transfers_of_different_kind(
         self,
     ) -> None:
         company1_name = "test company 1"

--- a/tests/services/test_account_details_service.py
+++ b/tests/services/test_account_details_service.py
@@ -465,4 +465,5 @@ class PlotDataTests(ServiceBase):
                 id=uuid4(),
                 name="Some counter party name",
             ),
+            debtor_equals_creditor=False,
         )

--- a/tests/services/test_account_details_service.py
+++ b/tests/services/test_account_details_service.py
@@ -1,12 +1,16 @@
 from datetime import datetime
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from parameterized import parameterized
 
+from arbeitszeit.anonymization import ANONYMIZED_STR, ANONYMIZED_UUID
+from arbeitszeit.records import SocialAccounting
 from arbeitszeit.services.account_details import (
     AccountDetailsService,
     AccountTransfer,
+    TransferParty,
+    TransferPartyType,
     construct_plot_data,
 )
 from arbeitszeit.transfers import TransferType
@@ -14,11 +18,32 @@ from tests.datetime_service import datetime_utc
 from tests.interactors.base_test_case import BaseTestCase
 
 
-class AccountTransfersTests(BaseTestCase):
+class ServiceBase(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.service = self.injector.get(AccountDetailsService)
 
+    def create_company_product_account(self) -> UUID:
+        return self.company_generator.create_company_record().means_account
+
+    def create_member_account(self) -> UUID:
+        self.member_generator.create_member()
+        member = self.database_gateway.get_members().first()
+        assert member
+        return member.account
+
+    def create_social_accounting_psf_account(self) -> UUID:
+        social_accounting = self.injector.get(SocialAccounting)
+        return social_accounting.account_psf
+
+    def create_cooperation_account(self) -> UUID:
+        self.cooperation_generator.create_cooperation()
+        cooperation = self.database_gateway.get_cooperations().first()
+        assert cooperation
+        return cooperation.account
+
+
+class AccountTransfersTests(ServiceBase):
     def test_no_transfers_returned_when_account_does_not_exist(self) -> None:
         assert not self.service.get_account_transfers(uuid4())
 
@@ -34,12 +59,12 @@ class AccountTransfersTests(BaseTestCase):
         assert not self.service.get_account_transfers(account)
 
     def test_that_transfers_to_account_are_returned(self) -> None:
-        account = self.company_generator.create_company_record().product_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(credit_account=account)
         assert self.service.get_account_transfers(account)
 
     def test_that_transfers_from_account_are_returned(self) -> None:
-        account = self.company_generator.create_company_record().product_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(debit_account=account)
         assert self.service.get_account_transfers(account)
 
@@ -47,7 +72,7 @@ class AccountTransfersTests(BaseTestCase):
     def test_that_correct_amount_of_transfers_from_account_are_returned(
         self, num_of_transfers: int
     ) -> None:
-        account = self.company_generator.create_company_record().product_account
+        account = self.create_company_product_account()
         for _ in range(num_of_transfers):
             self.transfer_generator.create_transfer(debit_account=account)
         assert len(self.service.get_account_transfers(account)) == num_of_transfers
@@ -56,7 +81,7 @@ class AccountTransfersTests(BaseTestCase):
     def test_that_correct_amount_of_transfers_to_account_are_returned(
         self, num_of_transfers: int
     ) -> None:
-        account = self.company_generator.create_company_record().product_account
+        account = self.create_company_product_account()
         for _ in range(num_of_transfers):
             self.transfer_generator.create_transfer(credit_account=account)
         assert len(self.service.get_account_transfers(account)) == num_of_transfers
@@ -84,7 +109,7 @@ class AccountTransfersTests(BaseTestCase):
     def test_transfer_type_is_passed_as_such(
         self, expected_transfer_type: TransferType
     ) -> None:
-        account = self.company_generator.create_company_record().means_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(
             type=expected_transfer_type, credit_account=account
         )
@@ -98,7 +123,7 @@ class AccountTransfersTests(BaseTestCase):
         ]
     )
     def test_transfer_date_is_passed_as_such(self, expected_date: datetime) -> None:
-        account = self.company_generator.create_company_record().means_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(
             date=expected_date, credit_account=account
         )
@@ -111,7 +136,7 @@ class AccountTransfersTests(BaseTestCase):
     def test_transfer_volume_is_passed_as_such_if_transfer_is_credit_transfer(
         self, expected_volume: Decimal
     ) -> None:
-        account = self.company_generator.create_company_record().means_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(
             value=expected_volume, credit_account=account
         )
@@ -124,17 +149,239 @@ class AccountTransfersTests(BaseTestCase):
     def test_transfer_volume_is_passed_with_inverted_sign_if_transfer_is_debit_transfer(
         self, volume: Decimal
     ) -> None:
-        account = self.company_generator.create_company_record().means_account
+        account = self.create_company_product_account()
         self.transfer_generator.create_transfer(value=volume, debit_account=account)
         transfers = self.service.get_account_transfers(account)
         assert transfers[0].volume == -volume
 
 
-class AccountBalanceTests(BaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.service = self.injector.get(AccountDetailsService)
+class TransferPartyTests(ServiceBase):
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_type_company_is_shown_if_transfer_party_is_company(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_member_account()
+        other_party_account = self.create_company_product_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.type == TransferPartyType.company
 
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_type_member_is_shown_if_transfer_party_is_member(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        other_party_account = self.create_member_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.type == TransferPartyType.member
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_type_social_accounting_is_shown_if_transfer_party_is_social_Accounting(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        other_party_account = self.create_social_accounting_psf_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.type == TransferPartyType.social_accounting
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_type_cooperation_is_shown_if_transfer_party_is_cooperation(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        other_party_account = self.create_cooperation_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.type == TransferPartyType.cooperation
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_id_is_anonymized_if_transfer_party_is_member(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        other_party_account = self.create_member_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.id is ANONYMIZED_UUID
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_transfer_party_name_is_anonymized_if_transfer_party_is_member(
+        self, is_debit_transfer: bool
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        other_party_account = self.create_member_account()
+        if is_debit_transfer:
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        else:
+            self.transfer_generator.create_transfer(
+                debit_account=other_party_account, credit_account=requesting_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.name == ANONYMIZED_STR
+
+    @parameterized.expand(
+        [
+            (TransferPartyType.company,),
+            (TransferPartyType.cooperation,),
+            (TransferPartyType.social_accounting,),
+        ]
+    )
+    def test_that_transfer_party_id_is_not_anonymized_if_transfer_party_is_not_member(
+        self, transfer_party_type: TransferPartyType
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        if transfer_party_type == TransferPartyType.company:
+            other_party_account = self.create_company_product_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        elif transfer_party_type == TransferPartyType.cooperation:
+            other_party_account = self.create_cooperation_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        elif transfer_party_type == TransferPartyType.social_accounting:
+            other_party_account = self.create_social_accounting_psf_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.id is not ANONYMIZED_UUID
+
+    @parameterized.expand(
+        [
+            (TransferPartyType.company,),
+            (TransferPartyType.cooperation,),
+            (TransferPartyType.social_accounting,),
+        ]
+    )
+    def test_that_transfer_party_name_is_not_anonymized_if_transfer_party_is_not_member(
+        self, transfer_party_type: TransferPartyType
+    ) -> None:
+        requesting_account = self.create_company_product_account()
+        if transfer_party_type == TransferPartyType.company:
+            other_party_account = self.create_company_product_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        elif transfer_party_type == TransferPartyType.cooperation:
+            other_party_account = self.create_cooperation_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        elif transfer_party_type == TransferPartyType.social_accounting:
+            other_party_account = self.create_social_accounting_psf_account()
+            self.transfer_generator.create_transfer(
+                debit_account=requesting_account, credit_account=other_party_account
+            )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.name is not ANONYMIZED_STR
+
+    def test_that_transfer_party_name_equals_company_name(self) -> None:
+        self.company_generator.create_company(name="Some Company Name")
+        company = self.database_gateway.get_companies().first()
+        assert company
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account, credit_account=company.means_account
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.name == "Some Company Name"
+
+    def test_that_transfer_party_id_equals_company_id(self) -> None:
+        self.company_generator.create_company()
+        company = self.database_gateway.get_companies().first()
+        assert company
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account, credit_account=company.means_account
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.id == company.id
+
+    def test_that_transfer_party_name_equals_cooperation_name(self) -> None:
+        self.cooperation_generator.create_cooperation(name="Some Cooperation Name")
+        cooperation = self.database_gateway.get_cooperations().first()
+        assert cooperation
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account, credit_account=cooperation.account
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.name == "Some Cooperation Name"
+
+    def test_that_transfer_party_id_equals_cooperation_id(self) -> None:
+        self.cooperation_generator.create_cooperation()
+        cooperation = self.database_gateway.get_cooperations().first()
+        assert cooperation
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account, credit_account=cooperation.account
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.id == cooperation.id
+
+    def test_that_transfer_party_name_equals_social_accounting_name(self) -> None:
+        social_accounting = self.injector.get(SocialAccounting)
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account,
+            credit_account=social_accounting.account_psf,
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.name == social_accounting.get_name()
+
+    def test_that_transfer_party_id_equals_social_accounting_id(self) -> None:
+        social_accounting = self.injector.get(SocialAccounting)
+        requesting_account = self.create_member_account()
+        self.transfer_generator.create_transfer(
+            debit_account=requesting_account,
+            credit_account=social_accounting.account_psf,
+        )
+        transfers = self.service.get_account_transfers(requesting_account)
+        assert transfers[0].transfer_party.id == social_accounting.id
+
+
+class AccountBalanceTests(ServiceBase):
     def test_balance_is_zero_when_no_transfers_took_place(self) -> None:
         account = self.company_generator.create_company_record().means_account
         balance = self.service.get_account_balance(account)
@@ -164,7 +411,7 @@ class AccountBalanceTests(BaseTestCase):
         assert self.service.get_account_balance(account) == Decimal(expected_balance)
 
 
-class PlotDataTests(BaseTestCase):
+class PlotDataTests(ServiceBase):
     def test_that_plotting_info_is_empty_when_empty_list_is_passed_in(self) -> None:
         plot_data = construct_plot_data([])
         assert not plot_data.accumulated_volumes
@@ -213,4 +460,9 @@ class PlotDataTests(BaseTestCase):
             date=date,
             is_debit_transfer=False,
             volume=volume,
+            transfer_party=TransferParty(
+                type=TransferPartyType.company,
+                id=uuid4(),
+                name="Some counter party name",
+            ),
         )

--- a/tests/www/presenters/test_get_member_account_presenter.py
+++ b/tests/www/presenters/test_get_member_account_presenter.py
@@ -164,4 +164,5 @@ class TestPresenter(BaseTestCase):
             transfer_party=TransferParty(
                 id=uuid4(), name="Some party name", type=TransferPartyType.member
             ),
+            debtor_equals_creditor=False,
         )

--- a/tests/www/presenters/test_get_member_account_presenter.py
+++ b/tests/www/presenters/test_get_member_account_presenter.py
@@ -136,6 +136,26 @@ class TestPresenter(BaseTestCase):
             self.translator.gettext("Contribution to public sector"),
         )
 
+    def test_that_transfer_party_name_is_translated_if_it_is_the_name_of_social_accounting(
+        self,
+    ) -> None:
+        nontranslated_social_accounting_name = "Social Accounting"
+        response = self.get_interactor_response(
+            [
+                self.get_transfer(
+                    transfer_party=TransferParty(
+                        id=uuid4(),
+                        name=nontranslated_social_accounting_name,
+                        type=TransferPartyType.social_accounting,
+                    )
+                )
+            ]
+        )
+        view_model = self.presenter.present_member_account(response)
+        assert view_model.transfers[0].party_name == self.translator.gettext(
+            nontranslated_social_accounting_name
+        )
+
     def get_interactor_response(
         self, transfers: list[AccountTransfer], balance: Optional[Decimal] = None
     ) -> GetMemberAccountResponse:
@@ -149,6 +169,7 @@ class TestPresenter(BaseTestCase):
         transfer_volume: Optional[Decimal] = None,
         type: Optional[TransferType] = None,
         is_debit_transfer: bool = False,
+        transfer_party: Optional[TransferParty] = None,
     ) -> AccountTransfer:
         if date is None:
             date = self.datetime_service.now()
@@ -156,13 +177,15 @@ class TestPresenter(BaseTestCase):
             transfer_volume = Decimal("20.006")
         if type is None:
             type = TransferType.work_certificates
+        if transfer_party is None:
+            transfer_party = TransferParty(
+                id=uuid4(), name="Some party name", type=TransferPartyType.member
+            )
         return AccountTransfer(
             date=date,
             volume=transfer_volume,
             type=type,
             is_debit_transfer=is_debit_transfer,
-            transfer_party=TransferParty(
-                id=uuid4(), name="Some party name", type=TransferPartyType.member
-            ),
+            transfer_party=transfer_party,
             debtor_equals_creditor=False,
         )

--- a/tests/www/presenters/test_list_transfers_presenter.py
+++ b/tests/www/presenters/test_list_transfers_presenter.py
@@ -153,7 +153,7 @@ class ResultsTests(ListTransfersPresenterBase):
         )
         view_model = self.presenter.present(uc_response)
         assert view_model.results.rows[0].transfer_type == self.translator.gettext(
-            "Credit for fixed means of production"
+            "Planned fixed means of production"
         )
 
     def test_that_debit_account_is_converted_to_string(self) -> None:

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -70,8 +70,8 @@ class ShowAAccountDetailsPresenterTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            (TransferType.credit_a, "Credit for labour"),
-            (TransferType.credit_public_a, "Credit for labour (public service)"),
+            (TransferType.credit_a, "Planned labour"),
+            (TransferType.credit_public_a, "Planned labour (public service)"),
             (TransferType.work_certificates, "Work certificates"),
         ]
     )

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -5,7 +5,12 @@ from uuid import UUID, uuid4
 from parameterized import parameterized
 
 from arbeitszeit.interactors import show_a_account_details
-from arbeitszeit.services.account_details import AccountTransfer, PlotDetails
+from arbeitszeit.services.account_details import (
+    AccountTransfer,
+    PlotDetails,
+    TransferParty,
+    TransferPartyType,
+)
 from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.www.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
@@ -122,7 +127,17 @@ class ShowAAccountDetailsPresenterTests(BaseTestCase):
     ) -> AccountTransfer:
         if date is None:
             date = self.datetime_service.now()
-        return AccountTransfer(transfer_type, date, transfer_volume, is_debit_transfer)
+        return AccountTransfer(
+            transfer_type,
+            date,
+            transfer_volume,
+            is_debit_transfer,
+            transfer_party=TransferParty(
+                type=TransferPartyType.company,
+                id=uuid4(),
+                name="Some counter party name",
+            ),
+        )
 
     def _interactor_response(
         self,

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -136,6 +136,7 @@ class ShowAAccountDetailsPresenterTests(BaseTestCase):
                 id=uuid4(),
                 name="Some counter party name",
             ),
+            debtor_equals_creditor=False,
         )
 
     def _interactor_response(

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -38,7 +38,6 @@ class ShowAAccountDetailsPresenterTests(BaseTestCase):
         self.assertTrue(len(view_model.transfers), 1)
         self.assertEqual(view_model.account_balance, str(round(ACCOUNT_BALANCE, 2)))
         trans = view_model.transfers[0]
-        self.assertEqual(trans.transfer_type, self.translator.gettext("Credit"))
         self.assertEqual(
             trans.date,
             self.datetime_formatter.format_datetime(
@@ -71,9 +70,9 @@ class ShowAAccountDetailsPresenterTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            (TransferType.credit_a, "Credit"),
-            (TransferType.credit_public_a, "Credit"),
-            (TransferType.work_certificates, "Payment"),
+            (TransferType.credit_a, "Credit for labour"),
+            (TransferType.credit_public_a, "Credit for labour (public service)"),
+            (TransferType.work_certificates, "Work certificates"),
         ]
     )
     def test_presenter_shows_correct_string_for_each_transfer_type(

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -58,7 +58,7 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
         [
             (
                 TransferType.credit_p,
-                "Credit for fixed means of production",
+                "Planned fixed means of production",
             ),
             (
                 TransferType.productive_consumption_p,

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -134,6 +134,7 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
             date=date,
             volume=volume,
             is_debit_transfer=is_debit_transfer,
+            debtor_equals_creditor=False,
             transfer_party=TransferParty(
                 type=TransferPartyType.company,
                 id=uuid4(),

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -7,7 +7,12 @@ from parameterized import parameterized
 from arbeitszeit.interactors.show_p_account_details import (
     ShowPAccountDetailsInteractor as Interactor,
 )
-from arbeitszeit.services.account_details import AccountTransfer, PlotDetails
+from arbeitszeit.services.account_details import (
+    AccountTransfer,
+    PlotDetails,
+    TransferParty,
+    TransferPartyType,
+)
 from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.www.presenters.show_p_account_details_presenter import (
     ShowPAccountDetailsPresenter,
@@ -106,7 +111,15 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
         is_debit_transfer: bool = False,
     ) -> AccountTransfer:
         return AccountTransfer(
-            type=type, date=date, volume=volume, is_debit_transfer=is_debit_transfer
+            type=type,
+            date=date,
+            volume=volume,
+            is_debit_transfer=is_debit_transfer,
+            transfer_party=TransferParty(
+                type=TransferPartyType.company,
+                id=uuid4(),
+                name="Some counter party name",
+            ),
         )
 
     def get_interactor_response(

--- a/tests/www/presenters/test_show_p_account_details_presenter.py
+++ b/tests/www/presenters/test_show_p_account_details_presenter.py
@@ -45,9 +45,6 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
         assert len(view_model.transfers) == 1
         view_model_transfer = view_model.transfers[0]
         self.assertEqual(
-            view_model_transfer.transfer_type, self.translator.gettext("Credit")
-        )
-        self.assertEqual(
             view_model_transfer.date,
             self.datetime_formatter.format_datetime(
                 date=transfer.date, fmt="%d.%m.%Y %H:%M"
@@ -55,6 +52,28 @@ class ShowPAccountDetailsPresenterTests(BaseTestCase):
         )
         self.assertEqual(
             view_model_transfer.transfer_volume, str(round(transfer.volume, 2))
+        )
+
+    @parameterized.expand(
+        [
+            (
+                TransferType.credit_p,
+                "Credit for fixed means of production",
+            ),
+            (
+                TransferType.productive_consumption_p,
+                "Productive consumption of fixed means of production",
+            ),
+        ]
+    )
+    def test_that_type_of_transfer_is_converted_into_correct_string(
+        self, transfer_type: TransferType, expected_string: str
+    ) -> None:
+        transfer = self.get_transfer_info(type=transfer_type)
+        response = self.get_interactor_response(transfers=[transfer])
+        view_model = self.presenter.present(response)
+        assert view_model.transfers[0].transfer_type == (
+            self.translator.gettext(expected_string)
         )
 
     @parameterized.expand([(True,), (False,)])

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -153,7 +153,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             ]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == self.translator.gettext(
+        assert view_model.transfers[0].party_name == self.translator.gettext(
             "Anonymous worker"
         )
 
@@ -171,7 +171,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             ]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == expected_name
+        assert view_model.transfers[0].party_name == expected_name
 
     def test_that_name_of_other_party_is_empty_string_if_company_is_debtor_and_creditor(
         self,
@@ -180,7 +180,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             transfers=[self._get_transfer_info(debtor_equals_creditor=True)]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == ""
+        assert view_model.transfers[0].party_name == ""
 
     def test_that_icon_of_other_party_is_empty_string_if_company_is_debtor_and_creditor(
         self,
@@ -189,7 +189,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             transfers=[self._get_transfer_info(debtor_equals_creditor=True)]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_type_icon == ""
+        assert view_model.transfers[0].party_icon == ""
 
     @parameterized.expand(
         [
@@ -213,7 +213,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
             ]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_type_icon == expected_icon
+        assert view_model.transfers[0].party_icon == expected_icon
 
     @parameterized.expand([(True,), (False,)])
     def test_that_debit_transfer_are_shown_as_such(

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -4,7 +4,13 @@ from uuid import UUID, uuid4
 
 from parameterized import parameterized
 
+from arbeitszeit.anonymization import ANONYMIZED_STR
 from arbeitszeit.interactors import show_prd_account_details
+from arbeitszeit.services.account_details import (
+    AccountTransfer,
+    TransferParty,
+    TransferPartyType,
+)
 from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.www.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
@@ -134,150 +140,91 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
         self.assertTrue(view_model.plot_url)
         self.assertIn(str(response.company_id), view_model.plot_url)
 
-    def test_name_of_peer_is_shown_if_transfer_is_productive_consumption(
+    def test_name_of_other_party_is_shown_correctly_if_party_name_is_anonymized(
         self,
     ) -> None:
-        expected_user_name = "some user name"
         response = self._interactor_response(
             transfers=[
                 self._get_transfer_info(
-                    transfer_type=TransferType.productive_consumption_p,
-                    peer=show_prd_account_details.CompanyPeer(
-                        id=uuid4(), name=expected_user_name
+                    transfer_party=TransferParty(
+                        type=TransferPartyType.company, id=uuid4(), name=ANONYMIZED_STR
                     ),
                 )
             ]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == expected_user_name
-
-    def test_name_of_peer_is_anonymized_if_transfer_is_private_consumption(
-        self,
-    ) -> None:
-        expected_user_name = self.translator.gettext("Anonymous worker")
-        response = self._interactor_response(
-            transfers=[
-                self._get_transfer_info(
-                    transfer_type=TransferType.private_consumption,
-                    peer=show_prd_account_details.MemberPeer(),
-                )
-            ]
+        assert view_model.transfers[0].peer_name == self.translator.gettext(
+            "Anonymous worker"
         )
-        view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == expected_user_name
 
-    def test_name_of_peer_is_shown_if_transfer_is_compensation_for_coop(
+    def test_name_of_other_party_is_shown_correctly_if_party_name_is_not_anonymized(
         self,
     ) -> None:
-        expected_coop_name = "some coop name"
+        expected_name = "Some party name"
         response = self._interactor_response(
             transfers=[
                 self._get_transfer_info(
-                    transfer_type=TransferType.compensation_for_coop,
-                    peer=show_prd_account_details.CooperationPeer(
-                        id=uuid4(), name=expected_coop_name
+                    transfer_party=TransferParty(
+                        type=TransferPartyType.company, id=uuid4(), name=expected_name
                     ),
                 )
             ]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == expected_coop_name
+        assert view_model.transfers[0].peer_name == expected_name
 
-    def test_name_of_peer_is_shown_if_transfer_is_compensation_for_company(
-        self,
-    ) -> None:
-        expected_company_name = "some company name"
-        response = self._interactor_response(
-            transfers=[
-                self._get_transfer_info(
-                    transfer_type=TransferType.compensation_for_company,
-                    peer=show_prd_account_details.CompanyPeer(
-                        id=uuid4(), name=expected_company_name
-                    ),
-                )
-            ]
-        )
-        view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == expected_company_name
-
-    def test_member_peer_icon_is_shown_if_transfer_was_with_member(
+    def test_that_name_of_other_party_is_empty_string_if_company_is_debtor_and_creditor(
         self,
     ) -> None:
         response = self._interactor_response(
-            transfers=[
-                self._get_transfer_info(
-                    transfer_type=TransferType.private_consumption,
-                    peer=show_prd_account_details.MemberPeer(),
-                )
-            ]
+            transfers=[self._get_transfer_info(debtor_equals_creditor=True)]
         )
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_type_icon == "user"
+        assert view_model.transfers[0].peer_name == ""
 
-    def test_company_peer_icon_is_shown_if_transfer_was_with_company(
+    def test_that_icon_of_other_party_is_empty_string_if_company_is_debtor_and_creditor(
         self,
     ) -> None:
         response = self._interactor_response(
-            transfers=[
-                self._get_transfer_info(
-                    transfer_type=TransferType.productive_consumption_p,
-                    peer=show_prd_account_details.CompanyPeer(
-                        id=uuid4(), name="company name"
-                    ),
-                )
-            ]
+            transfers=[self._get_transfer_info(debtor_equals_creditor=True)]
         )
-        view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_type_icon == "industry"
-
-    @parameterized.expand(
-        [
-            (TransferType.compensation_for_company),
-            (TransferType.compensation_for_coop),
-        ]
-    )
-    def test_peer_type_icon_is_hands_helping_if_transfer_was_with_cooperation(
-        self,
-        transfer_type: TransferType,
-    ) -> None:
-        response = self._interactor_response(
-            transfers=[
-                self._get_transfer_info(
-                    transfer_type=transfer_type,
-                    peer=show_prd_account_details.CooperationPeer(
-                        id=uuid4(), name="coop name"
-                    ),
-                )
-            ]
-        )
-        view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_type_icon == "hands-helping"
-
-    def test_peer_type_icon_is_empty_string_if_peer_is_none(
-        self,
-    ) -> None:
-        transfer = show_prd_account_details.TransferInfo(
-            type=TransferType.credit_p,
-            date=datetime_min_utc(),
-            volume=Decimal(10.007),
-            peer=None,
-        )
-        response = self._interactor_response(transfers=[transfer])
         view_model = self.presenter.present(response)
         assert view_model.transfers[0].peer_type_icon == ""
 
-    def test_name_of_peer_is_empty_string_if_peer_is_none(
-        self,
+    @parameterized.expand(
+        [
+            (TransferPartyType.member, "user"),
+            (TransferPartyType.company, "industry"),
+            (TransferPartyType.cooperation, "hands-helping"),
+        ]
+    )
+    def test_that_correct_icon_is_shown_per_transfer_party_type(
+        self, transfer_party_type: TransferPartyType, expected_icon: str
     ) -> None:
-        transfer = show_prd_account_details.TransferInfo(
-            type=TransferType.credit_p,
-            date=datetime_min_utc(),
-            volume=Decimal(10.007),
-            peer=None,
+        response = self._interactor_response(
+            transfers=[
+                self._get_transfer_info(
+                    transfer_party=TransferParty(
+                        id=uuid4(),
+                        name="Some party name",
+                        type=transfer_party_type,
+                    )
+                )
+            ]
         )
-        response = self._interactor_response(transfers=[transfer])
         view_model = self.presenter.present(response)
-        assert view_model.transfers[0].peer_name == ""
+        assert view_model.transfers[0].peer_type_icon == expected_icon
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_debit_transfer_are_shown_as_such(
+        self,
+        is_debit: bool,
+    ) -> None:
+        response = self._interactor_response(
+            transfers=[self._get_transfer_info(is_debit_transfer=is_debit)]
+        )
+        view_model = self.presenter.present(response)
+        assert view_model.transfers[0].is_debit_transfer == is_debit
 
     def test_view_model_contains_two_navbar_items(self) -> None:
         response = self._interactor_response()
@@ -303,7 +250,7 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
     def _interactor_response(
         self,
         company_id: UUID = uuid4(),
-        transfers: List[show_prd_account_details.TransferInfo] | None = None,
+        transfers: List[AccountTransfer] | None = None,
         account_balance: Decimal = Decimal(0),
         plot: show_prd_account_details.PlotDetails | None = None,
     ) -> show_prd_account_details.Response:
@@ -317,22 +264,23 @@ class ShowPRDAccountDetailsPresenterTests(BaseTestCase):
 
     def _get_transfer_info(
         self,
-        transfer_type: TransferType | None = None,
-        peer: (
-            show_prd_account_details.MemberPeer
-            | show_prd_account_details.CompanyPeer
-            | show_prd_account_details.CooperationPeer
-            | None
-        ) = None,
+        transfer_party: TransferParty | None = None,
         volume: Decimal = Decimal(10.007),
-    ) -> show_prd_account_details.TransferInfo:
-        if transfer_type is None:
-            transfer_type = TransferType.private_consumption
-        if peer is None:
-            peer = show_prd_account_details.MemberPeer()
-        return show_prd_account_details.TransferInfo(
+        transfer_type: TransferType = TransferType.private_consumption,
+        debtor_equals_creditor: bool = False,
+        is_debit_transfer: bool = False,
+    ) -> AccountTransfer:
+        if transfer_party is None:
+            transfer_party = TransferParty(
+                id=uuid4(),
+                name="Some party name",
+                type=TransferPartyType.company,
+            )
+        return AccountTransfer(
             type=transfer_type,
             date=datetime_min_utc(),
             volume=volume,
-            peer=peer,
+            is_debit_transfer=is_debit_transfer,
+            transfer_party=transfer_party,
+            debtor_equals_creditor=debtor_equals_creditor,
         )

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -50,11 +50,32 @@ class ShowRAccountDetailsPresenterTests(BaseTestCase):
         assert len(view_model.transfers) == 1
         assert view_model.account_balance == str(round(EXPECTED_ACCOUNT_BALANCE, 2))
         transfer = view_model.transfers[0]
-        assert transfer.transfer_type == self.trans.gettext("Credit")
         assert transfer.date == self.datetime_formatter.format_datetime(
             date=EXPECTED_DATE, fmt="%d.%m.%Y %H:%M"
         )
         assert transfer.transfer_volume == str(round(EXPECTED_VOLUME, 2))
+
+    @parameterized.expand(
+        [
+            (
+                TransferType.credit_r,
+                "Credit for liquid means of production",
+            ),
+            (
+                TransferType.productive_consumption_r,
+                "Productive consumption of liquid means of production",
+            ),
+        ]
+    )
+    def test_that_type_of_transfer_is_converted_into_correct_string(
+        self, transfer_type: TransferType, expected_string: str
+    ) -> None:
+        transfer = self.get_transfer_info(type=transfer_type)
+        response = self.get_interactor_response(transfers=[transfer])
+        view_model = self.presenter.present(response)
+        assert view_model.transfers[0].transfer_type == (
+            self.translator.gettext(expected_string)
+        )
 
     @parameterized.expand([(True,), (False,)])
     def test_that_debit_transfer_are_shown_as_such(

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -6,7 +6,11 @@ from uuid import UUID, uuid4
 from parameterized import parameterized
 
 from arbeitszeit.interactors import show_r_account_details
-from arbeitszeit.services.account_details import PlotDetails
+from arbeitszeit.services.account_details import (
+    PlotDetails,
+    TransferParty,
+    TransferPartyType,
+)
 from arbeitszeit.transfers import TransferType
 from arbeitszeit_web.www.presenters.show_r_account_details_presenter import (
     ShowRAccountDetailsPresenter,
@@ -113,6 +117,11 @@ class ShowRAccountDetailsPresenterTests(BaseTestCase):
             date=date,
             volume=volume,
             is_debit_transfer=is_debit,
+            transfer_party=TransferParty(
+                type=TransferPartyType.company,
+                id=uuid4(),
+                name="Some counter party name",
+            ),
         )
 
     def get_interactor_response(

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from arbeitszeit.interactors import show_r_account_details
 from arbeitszeit.services.account_details import (
+    AccountTransfer,
     PlotDetails,
     TransferParty,
     TransferPartyType,
@@ -130,10 +131,10 @@ class ShowRAccountDetailsPresenterTests(BaseTestCase):
         date: datetime | None = None,
         volume=Decimal(10),
         is_debit: bool = False,
-    ) -> show_r_account_details.AccountTransfer:
+    ) -> AccountTransfer:
         if date is None:
             date = datetime_min_utc()
-        return show_r_account_details.AccountTransfer(
+        return AccountTransfer(
             type=type,
             date=date,
             volume=volume,
@@ -143,6 +144,7 @@ class ShowRAccountDetailsPresenterTests(BaseTestCase):
                 id=uuid4(),
                 name="Some counter party name",
             ),
+            debtor_equals_creditor=False,
         )
 
     def get_interactor_response(

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -60,7 +60,7 @@ class ShowRAccountDetailsPresenterTests(BaseTestCase):
         [
             (
                 TransferType.credit_r,
-                "Credit for liquid means of production",
+                "Planned liquid means of production",
             ),
             (
                 TransferType.productive_consumption_r,


### PR DESCRIPTION
The main purpose of this Pull Request is to unify account transfer display logic across different accounts (company p, r, a and member accounts).

One motivation was to reduce code duplication, because we want to display transfers similarily in all accounts, probably also in the future.

The second motiviation was to simplify the upcoming implementation of the transfer reversal logic. Now it will be easier to program (and test) the display of the new reversal transfers in the different accounts - see issue #825.

Note that performances of some use cases have dropped because we are now providing more complex data via db joins in some interactors: 
- benchmark "show_r_account_details": master: 0.0264, this branch: 0.0780 seconds
- benchmark "show_prd_account_details": master: 0.1357, this branch: 0.2428 seconds