### PR TITLE
Delete db details from transfer business logic

### DIFF
--- a/arbeitszeit/transfers.py
+++ b/arbeitszeit/transfers.py
@@ -3,9 +3,6 @@ from enum import Enum
 
 class TransferType(Enum):
     """
-    Warning: These enum values map to database columns.
-    If you change them, you need to create a database migration.
-
     See https://arbeitszeitapp.readthedocs.io/en/latest/concepts.html for
     a documentation of the transfer types.
     """

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -2394,6 +2394,25 @@ class DatabaseGatewayImpl:
         value: Decimal,
         type: TransferType,
     ) -> records.Transfer:
+        KNOWN_TRANSFER_TYPES = [
+            "credit_p",
+            "credit_r",
+            "credit_a",
+            "credit_public_p",
+            "credit_public_r",
+            "credit_public_a",
+            "private_consumption",
+            "productive_consumption_p",
+            "productive_consumption_r",
+            "compensation_for_coop",
+            "compensation_for_company",
+            "work_certificates",
+            "taxes",
+        ]
+        if type.value not in KNOWN_TRANSFER_TYPES:
+            raise ValueError(
+                f"Invalid transfer type: {type}. Check if you need to create a db migration for {type.value}. Then add it to the whitelist."
+            )
         transfer = models.Transfer(
             id=str(uuid4()),
             date=date,

--- a/tests/flask_integration/database_gateway_impl/test_transfer_query_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_transfer_query_result.py
@@ -41,6 +41,14 @@ class TransferResultTests(FlaskTestCase):
         code_values = [member.value for member in TransferType]
         assert set(db_values) == set(code_values)
 
+    def test_that_transfers_with_all_existing_transfer_types_can_be_created(
+        self,
+    ) -> None:
+        transfer_types = [t for t in TransferType]
+        for type_ in transfer_types:
+            transfer = self.transfer_generator.create_transfer(type=type_)
+            assert transfer.type == type_
+
 
 class WhereAccountIsDebtorTests(FlaskTestCase):
     def test_that_where_account_is_debtor_yields_none_if_debit_account_is_not_in_db(


### PR DESCRIPTION
Business logic in "arbeitszeit" folder should not have to deal with db implementation details.